### PR TITLE
Feat/ts identity setup

### DIFF
--- a/components/restreamer/CHANGELOG.md
+++ b/components/restreamer/CHANGELOG.md
@@ -15,6 +15,7 @@ All user visible changes to this project will be documented in this file. This p
 
 - Web UI:
   - Allow to use multiple Teamspeak mixers per output ([#199]);
+  - Allow to specify `identity` of Teamspeak mixer ([#6], [#39])
 
 ### Miscellaneous
 - Server updates:
@@ -25,7 +26,10 @@ All user visible changes to this project will be documented in this file. This p
 - Added test for check file recording ([#197]);
 - Use FIFO for feeding data into FFmpeg in mixer output ([#199]);
 
+[#6]: /../../issues/6
+
 [e1faef9]: /../../commit/e1faef91cc8551505afdf7fc4622c530f9e2c6f6
+[#39]: /../../pull/39
 [#197]: /../../pull/197
 [#199]: /../../pull/199
 [#200]: /../../pull/200

--- a/components/restreamer/CHANGELOG.md
+++ b/components/restreamer/CHANGELOG.md
@@ -20,8 +20,10 @@ All user visible changes to this project will be documented in this file. This p
 ### Miscellaneous
 - Server updates:
   - `ffmpeg` from 4.4 to 5.1 ([e1faef9]);
-  - `SRS` server updated to v4.0-r1 ([e1faef9], [#200]).
+  - `SRS` server updated to v4.0-r1 ([e1faef9], [#200]);
 
+- Update Tokio to v1+, Actix to v4+ and related libs ([#193]);
+- Split `ffmpeg.rs` to separate modules ([#202]);
 - Dockerfile image moved from CentOS 7 to Ubuntu 20.04 ([#200]);
 - Added test for check file recording ([#197]);
 - Use FIFO for feeding data into FFmpeg in mixer output ([#199]);
@@ -30,9 +32,12 @@ All user visible changes to this project will be documented in this file. This p
 
 [e1faef9]: /../../commit/e1faef91cc8551505afdf7fc4622c530f9e2c6f6
 [#39]: /../../pull/39
+[#193]: /../../pull/193
 [#197]: /../../pull/197
 [#199]: /../../pull/199
 [#200]: /../../pull/200
+[#202]: /../../pull/202
+
 
 
 ## [0.5.0] · 2022-04-20

--- a/components/restreamer/client/cypress/integration/add_output_mixin.js
+++ b/components/restreamer/client/cypress/integration/add_output_mixin.js
@@ -31,7 +31,9 @@ describe('ADD MIXIN OUTPUT', () => {
 
   it('Set teamspeak', () => {
     const teamspeakToPaste = 'ts://ts.single.com/Single';
-    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>&identity=<identity>"]')
+    cy.get(
+      '[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>&identity=<identity>"]'
+    )
       .invoke('val', teamspeakToPaste)
       .trigger('input');
   });

--- a/components/restreamer/client/cypress/integration/add_output_mixin.js
+++ b/components/restreamer/client/cypress/integration/add_output_mixin.js
@@ -31,7 +31,7 @@ describe('ADD MIXIN OUTPUT', () => {
 
   it('Set teamspeak', () => {
     const teamspeakToPaste = 'ts://ts.single.com/Single';
-    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>"]')
+    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>&identity=<identity>"]')
       .invoke('val', teamspeakToPaste)
       .trigger('input');
   });

--- a/components/restreamer/client/cypress/integration/add_output_multiple_mixin.js
+++ b/components/restreamer/client/cypress/integration/add_output_multiple_mixin.js
@@ -31,7 +31,9 @@ describe('ADD MULTIPLE MIXIN OUTPUT', () => {
 
   it('Set first teamspeak', () => {
     const teamspeakToPaste = 'ts://ts.multiple.com/Multiple1';
-    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>&identity=<identity>"]')
+    cy.get(
+      '[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>&identity=<identity>"]'
+    )
       .invoke('val', teamspeakToPaste)
       .trigger('input');
   });
@@ -42,7 +44,9 @@ describe('ADD MULTIPLE MIXIN OUTPUT', () => {
 
   it('Set second teamspeak', () => {
     const teamspeakToPaste = 'ts://ts.multiple.com/Multiple2';
-    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>&identity=<identity>"]')
+    cy.get(
+      '[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>&identity=<identity>"]'
+    )
       .eq(1)
       .invoke('val', teamspeakToPaste)
       .trigger('input');
@@ -54,7 +58,9 @@ describe('ADD MULTIPLE MIXIN OUTPUT', () => {
 
   it('Set third teamspeak', () => {
     const teamspeakToPaste = 'ts://ts.multiple.com/Multiple3';
-    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>&identity=<identity>"]')
+    cy.get(
+      '[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>&identity=<identity>"]'
+    )
       .eq(2)
       .invoke('val', teamspeakToPaste)
       .trigger('input');

--- a/components/restreamer/client/cypress/integration/add_output_multiple_mixin.js
+++ b/components/restreamer/client/cypress/integration/add_output_multiple_mixin.js
@@ -31,7 +31,7 @@ describe('ADD MULTIPLE MIXIN OUTPUT', () => {
 
   it('Set first teamspeak', () => {
     const teamspeakToPaste = 'ts://ts.multiple.com/Multiple1';
-    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>"]')
+    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>&identity=<identity>"]')
       .invoke('val', teamspeakToPaste)
       .trigger('input');
   });
@@ -42,7 +42,7 @@ describe('ADD MULTIPLE MIXIN OUTPUT', () => {
 
   it('Set second teamspeak', () => {
     const teamspeakToPaste = 'ts://ts.multiple.com/Multiple2';
-    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>"]')
+    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>&identity=<identity>"]')
       .eq(1)
       .invoke('val', teamspeakToPaste)
       .trigger('input');
@@ -54,7 +54,7 @@ describe('ADD MULTIPLE MIXIN OUTPUT', () => {
 
   it('Set third teamspeak', () => {
     const teamspeakToPaste = 'ts://ts.multiple.com/Multiple3';
-    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>"]')
+    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>&identity=<identity>"]')
       .eq(2)
       .invoke('val', teamspeakToPaste)
       .trigger('input');

--- a/components/restreamer/client/src/components/Mixin.svelte
+++ b/components/restreamer/client/src/components/Mixin.svelte
@@ -38,12 +38,22 @@
       showError(e.message);
     }
   }
+
+  function hideIdentity(rawUrl) {
+    let url = new URL(rawUrl);
+    if (url.searchParams.get('identity')) {
+      url.searchParams.delete('identity');
+      url.searchParams.set('identity', '*****');
+    }
+
+    return url.toString();
+  }
 </script>
 
 <template>
   <div class="mixin">
     <i class="fas fa-wave-square" title="Mixed audio" />
-    <Url url={value.src} />
+    <Url url={hideIdentity(value.src)} />
     <Volume
       volume={value.volume}
       {restream_id}

--- a/components/restreamer/client/src/modals/OutputModal.svelte
+++ b/components/restreamer/client/src/modals/OutputModal.svelte
@@ -384,8 +384,9 @@
               If <code>name</code> is not specified than the label value will be
               used, if any, or a random generated one.
               <br />
-              If <code title="Should be escaped or it won't work">identity</code> is not specified than the a random generated
-              one.
+              If
+              <code title="Should be escaped or it won't work">identity</code> is
+              not specified than the a random generated one.
             </div>
           {/if}
         </fieldset>

--- a/components/restreamer/client/src/modals/OutputModal.svelte
+++ b/components/restreamer/client/src/modals/OutputModal.svelte
@@ -138,7 +138,6 @@
           let vars = {
             restream_id: v.restream_id,
             url: vs[vs.length - 1],
-            mixins: [],
           };
           if (vs.length > 1) {
             vars.label = vs[0];
@@ -151,7 +150,6 @@
           submit = JSON.parse(v.json.trim()).map((x) => ({
             restream_id: v.restream_id,
             url: sanitizeUrl(x.url),
-            mixins: [],
             ...(x.label && { label: sanitizeLabel(x.label) }),
             ...(x.preview_url && { preview_url: sanitizeUrl(x.preview_url) }),
           }));
@@ -165,7 +163,6 @@
       let vars = {
         restream_id: v.restream_id,
         url: sanitizeUrl(v.url),
-        mixins: [],
       };
       const label = sanitizeLabel(v.label);
       if (label !== '') {
@@ -356,7 +353,7 @@
               class="uk-input"
               type="text"
               bind:value={mix_url}
-              placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>"
+              placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>&identity=<identity>"
             />
           {/each}
 
@@ -383,6 +380,8 @@
               <br />
               If <code>name</code> is not specified than the label value will be
               used, if any, or a random generated one.
+              <br />
+              If <code>identity</code> is not specified than the a random generated one.
             </div>
           {/if}
         </fieldset>

--- a/components/restreamer/client/src/modals/OutputModal.svelte
+++ b/components/restreamer/client/src/modals/OutputModal.svelte
@@ -384,7 +384,7 @@
               If <code>name</code> is not specified than the label value will be
               used, if any, or a random generated one.
               <br />
-              If <code>identity</code> is not specified than the a random generated
+              If <code title="Should be escaped or it won't work">identity</code> is not specified than the a random generated
               one.
             </div>
           {/if}

--- a/components/restreamer/client/src/modals/OutputModal.svelte
+++ b/components/restreamer/client/src/modals/OutputModal.svelte
@@ -386,7 +386,7 @@
               <br />
               If
               <code title="Should be escaped or it won't work">identity</code> is
-              not specified than the a random generated one.
+              not specified then a random generated one is used.
             </div>
           {/if}
         </fieldset>

--- a/components/restreamer/client/src/modals/OutputModal.svelte
+++ b/components/restreamer/client/src/modals/OutputModal.svelte
@@ -138,6 +138,7 @@
           let vars = {
             restream_id: v.restream_id,
             url: vs[vs.length - 1],
+            mixins: [],
           };
           if (vs.length > 1) {
             vars.label = vs[0];
@@ -150,6 +151,7 @@
           submit = JSON.parse(v.json.trim()).map((x) => ({
             restream_id: v.restream_id,
             url: sanitizeUrl(x.url),
+            mixins: [],
             ...(x.label && { label: sanitizeLabel(x.label) }),
             ...(x.preview_url && { preview_url: sanitizeUrl(x.preview_url) }),
           }));
@@ -163,6 +165,7 @@
       let vars = {
         restream_id: v.restream_id,
         url: sanitizeUrl(v.url),
+        mixins: [],
       };
       const label = sanitizeLabel(v.label);
       if (label !== '') {

--- a/components/restreamer/client/src/modals/OutputModal.svelte
+++ b/components/restreamer/client/src/modals/OutputModal.svelte
@@ -384,7 +384,8 @@
               If <code>name</code> is not specified than the label value will be
               used, if any, or a random generated one.
               <br />
-              If <code>identity</code> is not specified than the a random generated one.
+              If <code>identity</code> is not specified than the a random generated
+              one.
             </div>
           {/if}
         </fieldset>


### PR DESCRIPTION
Allow to specify identity for particular teamspeak client. The identity must be escaped manually, the https://www.urlencoder.org/ could be used.

![image](https://user-images.githubusercontent.com/1163493/184506627-761431f8-2a11-4cd2-bab6-a3e0a0edbc34.png)
![Screenshot 2022-08-13 at 20 38 37](https://user-images.githubusercontent.com/1163493/184506673-8f2dafe6-308d-4143-ab91-714e0dfa6af2.png)

### Get identity from Teamspeak 
Open Identity window (Tools -> Identity) and export desired identity in the file system:
![image](https://user-images.githubusercontent.com/1163493/184507292-f7feb0b8-43c7-456c-bb7b-fd9862a17997.png)

Open the file and take full row of identity from the file:
The identity should be taken from exported identity file from `identity` section:
![Screenshot 2022-08-13 at 21 02 01](https://user-images.githubusercontent.com/1163493/184507363-871afbd3-6cae-463b-a8ca-d14c7d3ab610.png)


