### PR TITLE
Add identities for restreams, inputs and outputs in exported json

### DIFF
--- a/components/restreamer/src/api/graphql/client.rs
+++ b/components/restreamer/src/api/graphql/client.rs
@@ -161,6 +161,7 @@ impl MutationsRoot {
         let input_src = if with_backup {
             Some(spec::v1::InputSrc::FailoverInputs(vec![
                 spec::v1::Input {
+                    id: None,
                     key: InputKey::new("main").unwrap(),
                     endpoints: vec![spec::v1::InputEndpoint {
                         kind: InputEndpointKind::Rtmp,
@@ -169,6 +170,7 @@ impl MutationsRoot {
                     enabled: true,
                 },
                 spec::v1::Input {
+                    id: None,
                     key: InputKey::new("backup").unwrap(),
                     endpoints: vec![spec::v1::InputEndpoint {
                         kind: InputEndpointKind::Rtmp,
@@ -191,9 +193,11 @@ impl MutationsRoot {
         }
 
         let spec = spec::v1::Restream {
+            id: None,
             key,
             label,
             input: spec::v1::Input {
+                id: None,
                 key: InputKey::new("origin").unwrap(),
                 endpoints,
                 src: input_src,
@@ -375,6 +379,7 @@ impl MutationsRoot {
         }
 
         let spec = spec::v1::Output {
+            id: None,
             dst,
             label,
             preview_url,

--- a/components/restreamer/src/spec/v1.rs
+++ b/components/restreamer/src/spec/v1.rs
@@ -68,6 +68,9 @@ pub struct Settings {
 /// [`state::Restream`].
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Restream {
+    /// Unique ID of [`Restream`].
+    pub id: Option<state::RestreamId>,
+
     /// Unique key of this [`Restream`] identifying it, and used to form its
     /// endpoints URLs.
     pub key: state::RestreamKey,
@@ -114,6 +117,11 @@ impl Restream {
 /// Shareable (exportable and importable) specification of a [`state::Input`].
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Input {
+    /// Unique ID of this `Input`.
+    ///
+    /// Once assigned, it never changes.
+    pub id: Option<state::InputId>,
+
     /// Key of this [`Input`] to expose its [`InputEndpoint`]s with for
     /// accepting and serving a live stream.
     pub key: state::InputKey,
@@ -211,6 +219,7 @@ impl<'de> Deserialize<'de> for Input {
         }
 
         Ok(Self {
+            id: None,
             key: raw.key,
             endpoints: raw.endpoints,
             src: raw.src,
@@ -242,6 +251,11 @@ pub enum InputSrc {
 /// Shareable (exportable and importable) specification of a [`state::Output`].
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Output {
+    /// Unique ID of this `Output`.
+    ///
+    /// Once assigned, it never changes.
+    pub id: Option<state::OutputId>,
+
     /// Downstream URL to re-stream a live stream onto.
     pub dst: state::OutputDstUrl,
 

--- a/components/restreamer/src/state.rs
+++ b/components/restreamer/src/state.rs
@@ -739,6 +739,7 @@ impl Restream {
     #[must_use]
     pub fn export(&self) -> spec::v1::Restream {
         spec::v1::Restream {
+            id: Some(self.id),
             key: self.key.clone(),
             label: self.label.clone(),
             input: self.input.export(),
@@ -946,6 +947,7 @@ impl Input {
     #[must_use]
     pub fn export(&self) -> spec::v1::Input {
         spec::v1::Input {
+            id: Some(self.id),
             key: self.key.clone(),
             endpoints: self
                 .endpoints
@@ -1579,6 +1581,7 @@ impl Output {
     #[must_use]
     pub fn export(&self) -> spec::v1::Output {
         spec::v1::Output {
+            id: Some(self.id),
             dst: self.dst.clone(),
             label: self.label.clone(),
             preview_url: self.preview_url.clone(),


### PR DESCRIPTION
Fix for #96