### PR TITLE
Fix of Reqwest crash on sending kickoff_client

### DIFF
--- a/components/restreamer/Cargo.toml
+++ b/components/restreamer/Cargo.toml
@@ -29,7 +29,7 @@ once_cell = { version = "1.4", features = ["parking_lot"] }
 public-ip = "0.1"
 rand = "0.8"
 regex = "1.4"
-reqwest = { version = "0.11", features = ["json"], default-features = false }
+reqwest = { version = "0.10", features = ["json"], default-features = false }
 send_wrapper = { version = "0.5", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_humantime = { version = "1.0", package = "humantime-serde" }


### PR DESCRIPTION
Should resolve #59 and maybe #65.
For now the fix is lowering the version of reqwest until we will convert to Tokio1.x