### PR TITLE
Graphql schema of volume for mix page

### DIFF
--- a/components/restreamer/client/api/mix.graphql
+++ b/components/restreamer/client/api/mix.graphql
@@ -4,11 +4,17 @@ subscription Output($restreamId: RestreamId!, $outputId: OutputId!) {
         dst
         label
         previewUrl
-        volume
+        volume {
+            level
+            muted
+        }
         mixins {
             id
             src
-            volume
+            volume {
+                level
+                muted
+            }
             delay
         }
         enabled


### PR DESCRIPTION
The schema for mixer page was not updated, which resulted in error when opening the page.