### PR TITLE
Increase ts mixins per output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-task"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
+
+[[package]]
 name = "async-trait"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +520,12 @@ dependencies = [
  "quote 1.0.9",
  "syn 1.0.68",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -661,6 +684,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "brotli-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +796,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cache-padded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
+
+[[package]]
 name = "cc"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +887,15 @@ dependencies = [
  "either",
  "memchr",
  "unreachable",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
+dependencies = [
+ "cache-padded",
 ]
 
 [[package]]
@@ -1276,6 +1328,7 @@ dependencies = [
  "hex",
  "humantime",
  "humantime-serde",
+ "interprocess",
  "juniper",
  "juniper_actix",
  "juniper_graphql_ws",
@@ -1294,7 +1347,6 @@ dependencies = [
  "tokio 0.2.25",
  "tsclientlib",
  "tsproto-packets",
- "unix-named-pipe",
  "url",
  "uuid",
  "zeromq",
@@ -1343,25 +1395,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.2.8"
+name = "event-listener"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "failure"
@@ -1383,6 +1420,15 @@ dependencies = [
  "quote 1.0.9",
  "syn 1.0.68",
  "synstructure",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -1529,6 +1575,21 @@ name = "futures-io"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+
+[[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite 0.2.6",
+ "waker-fn",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1914,6 +1975,29 @@ checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "interprocess"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c58ec7fbda1df9a93f587b780659db3c99f61f4be27f9c82c9b37684ffd0366"
+dependencies = [
+ "blocking",
+ "cfg-if 1.0.0",
+ "futures",
+ "intmap",
+ "libc",
+ "once_cell",
+ "spinning",
+ "thiserror",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "intmap"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae52f28f45ac2bc96edb7714de995cffc174a395fb0abf5bff453587c980d7b9"
 
 [[package]]
 name = "iovec"
@@ -2438,6 +2522,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -3341,6 +3431,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spinning"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4052,16 +4151,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
-name = "unix-named-pipe"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad653da8f36ac5825ba06642b5a3cce14a4e52c6a5fab4a8928d53f4426dae2"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
 name = "unreachable"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4128,6 +4217,12 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,6 +1294,7 @@ dependencies = [
  "tokio 0.2.25",
  "tsclientlib",
  "tsproto-packets",
+ "unix-named-pipe",
  "url",
  "uuid",
  "zeromq",
@@ -1339,6 +1340,27 @@ dependencies = [
  "tokio 0.2.25",
  "tokio-util",
  "url",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -4028,6 +4050,16 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "unix-named-pipe"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ad653da8f36ac5825ba06642b5a3cce14a4e52c6a5fab4a8928d53f4426dae2"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "unreachable"

--- a/components/restreamer/CHANGELOG.md
+++ b/components/restreamer/CHANGELOG.md
@@ -10,8 +10,21 @@ All user visible changes to this project will be documented in this file. This p
 
 [Diff](/../../compare/restreamer-v0.5.0...restreamer-v0.6.0)
 
+
+### Added
+
+- Web UI:
+  - Allow to use multiple Teamspeak mixers per output ([#199]);
+
 ### Miscellaneous
-- Added test for check file recording
+- Server updates:
+  - `ffmpeg` from 4.4 to 5.1;
+  - `SRS` server updated to v4.0-b10.
+
+- Added test for check file recording;
+- Use FIFO for feeding data into FFmpeg in mixer output ([#199]);
+
+[#199]: /../../pull/199
 
 
 ## [0.5.0] · 2022-04-20

--- a/components/restreamer/Cargo.toml
+++ b/components/restreamer/Cargo.toml
@@ -40,7 +40,7 @@ structopt = "0.3"
 systemstat = "0.1.8"
 url = { version = "2.1", features = ["serde"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
-unix-named-pipe = "0.2.0"
+interprocess = "1.1.1"
 [dependencies.derive_more]
     version = "0.99.11"
     features = ["as_ref", "deref", "display", "error", "from"]

--- a/components/restreamer/Cargo.toml
+++ b/components/restreamer/Cargo.toml
@@ -40,6 +40,7 @@ structopt = "0.3"
 systemstat = "0.1.8"
 url = { version = "2.1", features = ["serde"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
+unix-named-pipe = "0.2.0"
 [dependencies.derive_more]
     version = "0.99.11"
     features = ["as_ref", "deref", "display", "error", "from"]

--- a/components/restreamer/client/cypress/integration/add_output_mixin.js
+++ b/components/restreamer/client/cypress/integration/add_output_mixin.js
@@ -30,7 +30,7 @@ describe('ADD MIXIN OUTPUT', () => {
   });
 
   it('Set teamspeak', () => {
-    const teamspeakToPaste = 'ts://allatra.ruvoice.com:10335/Translation/Music';
+    const teamspeakToPaste = 'ts://ts.single.com/Single';
     cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>"]')
       .invoke('val', teamspeakToPaste)
       .trigger('input');
@@ -43,9 +43,9 @@ describe('ADD MIXIN OUTPUT', () => {
 
   it('Assert', () => {
     cy.get("span:contains('Teamspeak')").should('have.text', 'Teamspeak');
-    cy.get("span:contains('/Translation/Music')").should(
+    cy.get("span:contains('/Single')").should(
       'have.text',
-      'ts://allatra.ruvoice.com:10335/Translation/Music'
+      'ts://ts.single.com/Single'
     );
   });
 });

--- a/components/restreamer/client/cypress/integration/add_output_multiple_mixin.js
+++ b/components/restreamer/client/cypress/integration/add_output_multiple_mixin.js
@@ -42,9 +42,10 @@ describe('ADD MULTIPLE MIXIN OUTPUT', () => {
 
   it('Set second teamspeak', () => {
     const teamspeakToPaste = 'ts://ts.multiple.com/Multiple2';
-    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>"]').eq(1)
-        .invoke('val', teamspeakToPaste)
-        .trigger('input');
+    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>"]')
+      .eq(1)
+      .invoke('val', teamspeakToPaste)
+      .trigger('input');
   });
 
   it('Checks a "with mixin" checkbox', () => {
@@ -53,9 +54,10 @@ describe('ADD MULTIPLE MIXIN OUTPUT', () => {
 
   it('Set third teamspeak', () => {
     const teamspeakToPaste = 'ts://ts.multiple.com/Multiple3';
-    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>"]').eq(2)
-        .invoke('val', teamspeakToPaste)
-        .trigger('input');
+    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>"]')
+      .eq(2)
+      .invoke('val', teamspeakToPaste)
+      .trigger('input');
   });
 
   it('Submits', () => {
@@ -65,18 +67,20 @@ describe('ADD MULTIPLE MIXIN OUTPUT', () => {
 
   it('Assert', () => {
     cy.get("span:contains('Teamspeak Multiple Test')").should(
-        'have.text', 'Teamspeak Multiple Test')
+      'have.text',
+      'Teamspeak Multiple Test'
+    );
     cy.get("span:contains('/Multiple1')").should(
-          'have.text',
-          'ts://ts.multiple.com/Multiple1'
-      );
+      'have.text',
+      'ts://ts.multiple.com/Multiple1'
+    );
     cy.get("span:contains('/Multiple2')").should(
-        'have.text',
-        'ts://ts.multiple.com/Multiple2'
+      'have.text',
+      'ts://ts.multiple.com/Multiple2'
     );
     cy.get("span:contains('/Multiple3')").should(
-        'have.text',
-        'ts://ts.multiple.com/Multiple3'
+      'have.text',
+      'ts://ts.multiple.com/Multiple3'
     );
   });
 });

--- a/components/restreamer/client/cypress/integration/add_output_multiple_mixin.js
+++ b/components/restreamer/client/cypress/integration/add_output_multiple_mixin.js
@@ -1,0 +1,82 @@
+describe('ADD MULTIPLE MIXIN OUTPUT', () => {
+  it('Goes to the homepage', () => {
+    cy.visit('/');
+  });
+  it('Click Output', () => {
+    cy.get("span:contains('Output'):last").click();
+    cy.wait(5000);
+  });
+
+  it('Set optional label', () => {
+    cy.get('[placeholder="optional label"]').type('Teamspeak Multiple Test');
+  });
+
+  it('Set rtmp://', () => {
+    const urlToPaste = 'rtmp://' + Cypress.env('host') + '/it/backup';
+    cy.get('[placeholder="rtmp://..."]')
+      .invoke('val', urlToPaste)
+      .trigger('input');
+  });
+
+  it('Set preview', () => {
+    const previewToPaste = 'https://www.youtube.com/watch?v=99567P5FiD0';
+    cy.get('[placeholder="optional preview url"]')
+      .invoke('val', previewToPaste)
+      .trigger('input');
+  });
+
+  it('Checks a "with mixin" checkbox', () => {
+    cy.get('.mix-with > [type="checkbox"]').check();
+  });
+
+  it('Set first teamspeak', () => {
+    const teamspeakToPaste = 'ts://ts.multiple.com/Multiple1';
+    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>"]')
+      .invoke('val', teamspeakToPaste)
+      .trigger('input');
+  });
+
+  it('Checks a "with mixin" checkbox', () => {
+    cy.get('.mix-with > [type="checkbox"]').check();
+  });
+
+  it('Set second teamspeak', () => {
+    const teamspeakToPaste = 'ts://ts.multiple.com/Multiple2';
+    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>"]').eq(1)
+        .invoke('val', teamspeakToPaste)
+        .trigger('input');
+  });
+
+  it('Checks a "with mixin" checkbox', () => {
+    cy.get('.mix-with > [type="checkbox"]').check();
+  });
+
+  it('Set third teamspeak', () => {
+    const teamspeakToPaste = 'ts://ts.multiple.com/Multiple3';
+    cy.get('[placeholder="ts://<teamspeak-host>:<port>/<channel>?name=<name>"]').eq(2)
+        .invoke('val', teamspeakToPaste)
+        .trigger('input');
+  });
+
+  it('Submits', () => {
+    cy.get("button:contains('Add')").click();
+    cy.get("button:contains('Add')").should('not.exist');
+  });
+
+  it('Assert', () => {
+    cy.get("span:contains('Teamspeak Multiple Test')").should(
+        'have.text', 'Teamspeak Multiple Test')
+    cy.get("span:contains('/Multiple1')").should(
+          'have.text',
+          'ts://ts.multiple.com/Multiple1'
+      );
+    cy.get("span:contains('/Multiple2')").should(
+        'have.text',
+        'ts://ts.multiple.com/Multiple2'
+    );
+    cy.get("span:contains('/Multiple3')").should(
+        'have.text',
+        'ts://ts.multiple.com/Multiple3'
+    );
+  });
+});

--- a/components/restreamer/client/cypress/integration/add_output_multiple_mixin.js
+++ b/components/restreamer/client/cypress/integration/add_output_multiple_mixin.js
@@ -12,7 +12,7 @@ describe('ADD MULTIPLE MIXIN OUTPUT', () => {
   });
 
   it('Set rtmp://', () => {
-    const urlToPaste = 'rtmp://' + Cypress.env('host') + '/it/backup';
+    const urlToPaste = 'rtmp://' + Cypress.env('host') + '/it/some';
     cy.get('[placeholder="rtmp://..."]')
       .invoke('val', urlToPaste)
       .trigger('input');

--- a/components/restreamer/client/cypress/support/commands.js
+++ b/components/restreamer/client/cypress/support/commands.js
@@ -170,7 +170,15 @@ Cypress.Commands.add('importJsonConf', (host) => {
           "preview_url": "https://www.youtube.com/watch?v=99567P5FiD0",
           "mixins": [
             {
-              "src": "ts://ts.sameteem.com:9987/AFK\/Muted",
+              "src": "ts://ts.sameteem.com:9987/AFK\\\\/Muted",
+              "delay": "3s 500ms"
+            },
+            {
+              "src": "ts://ts.sameteem.com:9987/AFK\\\\/Muted?name=MusicTest",
+              "delay": "3s 500ms"
+            },
+            {
+              "src": "ts://ts.sameteem.com:9987/AFK\\\\/Muted?name=MusicTest2",
               "delay": "3s 500ms"
             }
           ],

--- a/components/restreamer/client/cypress/support/commands.js
+++ b/components/restreamer/client/cypress/support/commands.js
@@ -170,7 +170,7 @@ Cypress.Commands.add('importJsonConf', (host) => {
           "preview_url": "https://www.youtube.com/watch?v=99567P5FiD0",
           "mixins": [
             {
-              "src": "ts://allatra.ruvoice.com:10335/Translation/Music",
+              "src": "ts://ts.sameteem.com:9987/AFK\/Muted",
               "delay": "3s 500ms"
             }
           ],

--- a/components/restreamer/src/api/graphql/client.rs
+++ b/components/restreamer/src/api/graphql/client.rs
@@ -418,7 +418,7 @@ impl MutationsRoot {
                     "TOO_MUCH_TEAMSPEAK_MIXIN_URLS",
                 )
                 .status(StatusCode::BAD_REQUEST)
-                .message("Only 3 TeamSpeak URLs are allowed"));
+                .message("Maximum 3 TeamSpeak URLs are allowed"));
             }
         }
 

--- a/components/restreamer/src/api/graphql/client.rs
+++ b/components/restreamer/src/api/graphql/client.rs
@@ -412,13 +412,13 @@ impl MutationsRoot {
                         )));
                 }
             }
-            if mixins.iter().filter(|u| u.scheme() == "ts").take(2).count() > 1
+            if mixins.iter().filter(|u| u.scheme() == "ts").take(4).count() > 3
             {
                 return Err(graphql::Error::new(
                     "TOO_MUCH_TEAMSPEAK_MIXIN_URLS",
                 )
                 .status(StatusCode::BAD_REQUEST)
-                .message("Only one TeamSpeak URL is allowed"));
+                .message("Only 3 TeamSpeak URLs are allowed"));
             }
         }
 

--- a/components/restreamer/src/ffmpeg.rs
+++ b/components/restreamer/src/ffmpeg.rs
@@ -21,6 +21,7 @@ use tokio::{io, process::Command, sync::Mutex, time};
 use url::Url;
 use uuid::Uuid;
 
+use crate::teamspeak::Input;
 use crate::{
     display_panic, dvr,
     state::{self, Delay, MixinId, MixinSrcUrl, State, Status, Volume},
@@ -1047,17 +1048,30 @@ impl MixingRestreamer {
     /// [TeamSpeak]: https://teamspeak.com
     async fn run_ffmpeg(&self, mut cmd: Command) -> io::Result<()> {
         let _ = cmd.spawn()?;
+
         let mut src_to_file = vec![];
         for m in self.mixins.iter() {
             if let Some(i) = m.stdin.as_ref() {
-                let mut src = i.lock().await;
+                let mut src = Arc::clone(i);
                 let mut write_to_pipe = File::create(&m.pipe_file_path).await?;
+
                 src_to_file.push((src, write_to_pipe));
             }
         }
+
+        async fn run_copy(
+            input: Arc<Mutex<Input>>,
+            mut file: File,
+        ) -> io::Result<()> {
+            let mut src = input.lock().await;
+            io::copy(&mut *src, &mut file).await?;
+
+            Ok(())
+        }
+
         let mut copy_futures = FuturesUnordered::new();
-        for (mut src, mut file) in src_to_file.iter_mut() {
-            copy_futures.push(io::copy(&mut *src, &mut file));
+        for (input, file) in src_to_file {
+            copy_futures.push(tokio::spawn(run_copy(input, file)));
         }
 
         while let Some(future) = copy_futures.next().await {

--- a/components/restreamer/src/ffmpeg.rs
+++ b/components/restreamer/src/ffmpeg.rs
@@ -933,15 +933,17 @@ impl MixingRestreamer {
         for (n, mixin) in self.mixins.iter().enumerate() {
             let mut extra_filters = String::new();
 
+            let mut ts_pipe: i8 = -1;
             let _ = match mixin.url.scheme() {
                 "ts" => {
                     extra_filters.push_str("aresample=async=1,");
+                    ts_pipe += 1;
                     cmd.args(&["-thread_queue_size", "512"])
                         .args(&["-f", "f32be"])
                         .args(&["-sample_rate", "48000"])
                         .args(&["-channels", "2"])
                         .args(&["-use_wallclock_as_timestamps", "true"])
-                        .args(&["-i", "pipe:0"])
+                        .args(&["-i", &format!("pipe:{}", ts_pipe)])
                 }
 
                 "http" | "https"

--- a/components/restreamer/src/ffmpeg.rs
+++ b/components/restreamer/src/ffmpeg.rs
@@ -939,7 +939,8 @@ impl MixingRestreamer {
                         .args(&["-sample_rate", "48000"])
                         .args(&["-channels", "2"])
                         .args(&["-use_wallclock_as_timestamps", "true"])
-                        .args(&["-i", mixin.get_fifo_path().to_str().unwrap()])
+                        .arg("-i")
+                        .arg(mixin.get_fifo_path())
                 }
 
                 "http" | "https"

--- a/components/restreamer/src/ffmpeg.rs
+++ b/components/restreamer/src/ffmpeg.rs
@@ -1047,7 +1047,7 @@ impl MixingRestreamer {
     /// [FFmpeg]: https://ffmpeg.org
     /// [TeamSpeak]: https://teamspeak.com
     async fn run_ffmpeg(&self, mut cmd: Command) -> io::Result<()> {
-        let _ = cmd.spawn()?;
+        let process = cmd.spawn()?;
 
         let mut copy_futures = FuturesUnordered::new();
         for m in self.mixins.iter() {
@@ -1072,6 +1072,7 @@ impl MixingRestreamer {
 
             Ok(())
         }
+        let out = process.wait_with_output().await?;
 
         while let Some(future) = copy_futures.next().await {
             let _ = future.map_err(|e| {

--- a/components/restreamer/src/lib.rs
+++ b/components/restreamer/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! [RTMP]: https://en.wikipedia.org/wiki/Real-Time_Messaging_Protocol
 
+// `too_many_lines` only for generated static needed. TODO: find a way to remove
+#![allow(clippy::too_many_lines)]
 #![deny(
     rustdoc::broken_intra_doc_links,
     missing_debug_implementations,

--- a/components/restreamer/src/spec/v1.rs
+++ b/components/restreamer/src/spec/v1.rs
@@ -314,7 +314,8 @@ impl Output {
                     ts_count += 1;
                     if ts_count > 3 {
                         return Err(D::Error::custom(format!(
-                            "Maximum 3 TeamSpeak Mixin.src allowed in in Output.mixins: {}",
+                            "Maximum 3 TeamSpeak Mixin.src allowed \
+                            in Output.mixins: {}",
                             m.src,
                         )));
                     }

--- a/components/restreamer/src/spec/v1.rs
+++ b/components/restreamer/src/spec/v1.rs
@@ -302,7 +302,7 @@ impl Output {
 
         if !mixins.is_empty() {
             let mut unique = HashSet::with_capacity(mixins.len());
-            let mut has_ts = false;
+            let mut ts_count: u8 = 0;
             for m in &mixins {
                 if let Some(src) = unique.replace(&m.src) {
                     return Err(D::Error::custom(format!(
@@ -311,13 +311,13 @@ impl Output {
                     )));
                 }
                 if m.src.scheme() == "ts" {
-                    if has_ts {
+                    ts_count += 1;
+                    if ts_count > 3 {
                         return Err(D::Error::custom(format!(
-                            "Second TeamSpeak Mixin.src in Output.mixins: {}",
+                            "Maximum 3 TeamSpeak Mixin.src allowed in in Output.mixins: {}",
                             m.src,
                         )));
                     }
-                    has_ts = true;
                 }
             }
         }

--- a/components/restreamer/src/teamspeak.rs
+++ b/components/restreamer/src/teamspeak.rs
@@ -389,7 +389,11 @@ impl AudioCapture {
         cfg: Config,
         audio: Arc<Mutex<AudioHandler>>,
     ) -> Result<(), AudioCaptureError> {
-        log::debug!("Connecting to TeamSpeak server...");
+        log::debug!(
+            "Connecting to TeamSpeak server: {:?}/{:?}",
+            cfg.get_address(),
+            cfg.get_channel()
+        );
         let conn = cfg
             .hardware_id(Self::new_hwid())
             .connect()

--- a/components/restreamer/src/teamspeak.rs
+++ b/components/restreamer/src/teamspeak.rs
@@ -391,7 +391,7 @@ impl AudioCapture {
         audio: Arc<Mutex<AudioHandler>>,
     ) -> Result<(), AudioCaptureError> {
         log::debug!(
-            "Connecting to TeamSpeak server: {:?}/{:?}",
+            "Connecting to TeamSpeak server: {}/{:?}",
             cfg.get_address(),
             cfg.get_channel()
         );


### PR DESCRIPTION
We've had a limitation to have only one ts mixer per output. 

It was so because internally was based on unnamed pipes. Each output had run FFmpeg with one stdin unnamed pipe. Data from the Teamspeak was fed into it. 

But the issue that one process could accept only one unnamed pipe, so we cannot scale.

The solution was in use of [FIFO](https://www.unix.com/man-page/linux/7/fifo/), or named pipes. [FIFO](https://www.unix.com/man-page/linux/7/fifo/) is kind a regular file which could be fed into FFmpeg. 