### PR TITLE
Update dockerimage to use latest SRSv4-r1

### DIFF
--- a/components/restreamer/CHANGELOG.md
+++ b/components/restreamer/CHANGELOG.md
@@ -18,13 +18,17 @@ All user visible changes to this project will be documented in this file. This p
 
 ### Miscellaneous
 - Server updates:
-  - `ffmpeg` from 4.4 to 5.1;
-  - `SRS` server updated to v4.0-b10.
+  - `ffmpeg` from 4.4 to 5.1 ([e1faef9]);
+  - `SRS` server updated to v4.0-r1 ([e1faef9], [#200]).
 
-- Added test for check file recording;
+- Dockerfile image moved from CentOS 7 to Ubuntu 20.04 ([#200]);
+- Added test for check file recording ([#197]);
 - Use FIFO for feeding data into FFmpeg in mixer output ([#199]);
 
+[e1faef9]: /../../commit/e1faef91cc8551505afdf7fc4622c530f9e2c6f6
+[#197]: /../../pull/197
 [#199]: /../../pull/199
+[#200]: /../../pull/200
 
 
 ## [0.5.0] · 2022-04-20

--- a/components/restreamer/Dockerfile
+++ b/components/restreamer/Dockerfile
@@ -2,9 +2,17 @@
 # Stage 'build-ephyr' builds Ephyr for the final stage.
 #
 
-# https://github.com/jrottenberg/ffmpeg/blob/master/docker-images/5.1/centos7/Dockerfile
-FROM jrottenberg/ffmpeg:5.1-centos7 AS build-ephyr
+# https://github.com/jrottenberg/ffmpeg/blob/master/docker-images/5.1/ubuntu2004/Dockerfile
+FROM jrottenberg/ffmpeg:5.1-ubuntu2004 AS build-ephyr
 
+# Update
+RUN apt-get update && apt-get install -y curl
+# Install build dependencies.
+RUN apt-get update \
+ && apt-get install -y curl \
+ && apt-get install -y build-essential \
+ && apt-get install -y automake gcc libtool make \
+                                     openssl-dev \
 
 # Install Rust.
 WORKDIR /tmp/rust/
@@ -26,12 +34,6 @@ RUN curl -sLO https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/
 # Install Node.js and Yarn.
 RUN (curl -Ls install-node.vercel.app/16 | bash -s -- --yes) \
  && npm install -g yarn
-
-
-# Install build dependencies.
-RUN yum --enablerepo=extras install -y epel-release \
- && yum --enablerepo=epel install -y automake gcc libtool make \
-                                     openssl-devel
 
 
 # First, build all the dependencies to cache them in a separate Docker layer and
@@ -93,7 +95,7 @@ RUN cargo build -p ephyr-restreamer --bin ephyr-restreamer --release
 #
 
 # https://github.com/ossrs/srs/releases/tag/v4.0-b10
-FROM ossrs/srs:v4.0-b10 AS build-srs
+FROM ossrs/srs:v4 AS build-srs
 
 
 
@@ -102,8 +104,8 @@ FROM ossrs/srs:v4.0-b10 AS build-srs
 # Stage 'runtime' creates final Docker image to use in runtime.
 #
 
-# https://github.com/jrottenberg/ffmpeg/blob/master/docker-images/5.1/centos7/Dockerfile
-FROM jrottenberg/ffmpeg:5.1-centos7 AS runtime
+# https://github.com/jrottenberg/ffmpeg/blob/master/docker-images/5.1/ubuntu2004/Dockerfile
+FROM jrottenberg/ffmpeg:5.1-ubuntu2004 AS runtime
 
 COPY --from=build-srs /usr/local/srs/ /usr/local/srs/
 

--- a/components/restreamer/Dockerfile
+++ b/components/restreamer/Dockerfile
@@ -5,14 +5,13 @@
 # https://github.com/jrottenberg/ffmpeg/blob/master/docker-images/5.1/ubuntu2004/Dockerfile
 FROM jrottenberg/ffmpeg:5.1-ubuntu2004 AS build-ephyr
 
-# Update
-RUN apt-get update && apt-get install -y curl
+
+
 # Install build dependencies.
 RUN apt-get update \
  && apt-get install -y curl \
  && apt-get install -y build-essential \
- && apt-get install -y automake gcc libtool make \
-                                     openssl-dev \
+ && apt-get install -y automake gcc libtool make libssl-dev
 
 # Install Rust.
 WORKDIR /tmp/rust/
@@ -48,7 +47,6 @@ COPY components/vod-meta-server/Cargo.toml ./components/vod-meta-server/
 COPY Cargo.toml Cargo.lock ./
 
 COPY components/restreamer/client.graphql.schema.json ./components/restreamer/
-
 
 
 RUN mkdir -p common/api/allatra-video/src/ \

--- a/components/restreamer/Dockerfile
+++ b/components/restreamer/Dockerfile
@@ -9,9 +9,9 @@ FROM jrottenberg/ffmpeg:5.1-ubuntu2004 AS build-ephyr
 
 # Install build dependencies.
 RUN apt-get update \
- && apt-get install -y curl \
- && apt-get install -y build-essential \
- && apt-get install -y automake gcc libtool make libssl-dev
+ && apt-get install -yq curl \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -yq pkg-config \
+ && apt-get install -yq build-essential automake gcc libtool make libssl-dev
 
 # Install Rust.
 WORKDIR /tmp/rust/

--- a/components/restreamer/Dockerfile
+++ b/components/restreamer/Dockerfile
@@ -92,8 +92,8 @@ RUN cargo build -p ephyr-restreamer --bin ephyr-restreamer --release
 # Stage 'build-srs' prepares SRS distribution for the final stage.
 #
 
-# https://github.com/ossrs/srs/releases/tag/v4.0-b10
-FROM ossrs/srs:v4 AS build-srs
+# https://github.com/ossrs/srs/releases/tag/v4.0-r1
+FROM ossrs/srs:v4.0-r1 AS build-srs
 
 
 

--- a/components/restreamer/Dockerfile
+++ b/components/restreamer/Dockerfile
@@ -32,7 +32,7 @@ RUN curl -sLO https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/
 
 # Install Node.js and Yarn.
 RUN (curl -Ls install-node.vercel.app/16 | bash -s -- --yes) \
- && npm install -g yarn
+ && npm install --location=global yarn
 
 
 # First, build all the dependencies to cache them in a separate Docker layer and

--- a/components/restreamer/Dockerfile
+++ b/components/restreamer/Dockerfile
@@ -2,7 +2,7 @@
 # Stage 'build-ephyr' builds Ephyr for the final stage.
 #
 
-# https://github.com/jrottenberg/ffmpeg/blob/master/docker-images/4.4/centos7/Dockerfile
+# https://github.com/jrottenberg/ffmpeg/blob/master/docker-images/5.1/centos7/Dockerfile
 FROM jrottenberg/ffmpeg:5.1-centos7 AS build-ephyr
 
 
@@ -102,7 +102,7 @@ FROM ossrs/srs:v4.0-b10 AS build-srs
 # Stage 'runtime' creates final Docker image to use in runtime.
 #
 
-# https://github.com/jrottenberg/ffmpeg/blob/master/docker-images/4.4/centos7/Dockerfile
+# https://github.com/jrottenberg/ffmpeg/blob/master/docker-images/5.1/centos7/Dockerfile
 FROM jrottenberg/ffmpeg:5.1-centos7 AS runtime
 
 COPY --from=build-srs /usr/local/srs/ /usr/local/srs/

--- a/components/restreamer/Makefile
+++ b/components/restreamer/Makefile
@@ -196,7 +196,7 @@ docker-image-tag = $(if $(call eq,$(tag),),$(IMAGE_TAG),$(tag))
 
 docker.image:
 	cd ../../ && \
-	docker build --network=host --force-rm \
+	docker build --network=host --force-rm --platform linux/amd64 \
 		$(if $(call eq,$(no-cache),yes),--no-cache --pull,) \
 		--file=components/restreamer/Dockerfile \
 		-t $(IMAGE_NAME):restreamer$(if \
@@ -232,7 +232,7 @@ docker.up: docker.down
 ifeq ($(rebuild),yes)
 	@make docker.image tag=$(tag) no-cache=$(no-cache)
 endif
-	docker run --rm --name ephyr-restreamer-dev \
+	docker run --rm --name ephyr-restreamer-dev --platform linux/amd64 \
 	           $(if $(call eq,$(background),yes),-d,-it) \
 	           -p 80:80 -p 1935:1935 -p 8000:8000 \
 	           -v '$(PWD)/state.json:/state.json' \


### PR DESCRIPTION
Latest SRS Dockerfile image moved from CentOS 7 to Ubuntu 20.04. Updating on our side as well.