### PR TITLE
Feature/ Mixin sidechain

### DIFF
--- a/components/restreamer/CHANGELOG.md
+++ b/components/restreamer/CHANGELOG.md
@@ -15,7 +15,8 @@ All user visible changes to this project will be documented in this file. This p
 
 - Web UI:
   - Allow to use multiple Teamspeak mixers per output ([#199]);
-  - Allow to specify `identity` of Teamspeak mixer ([#6], [#39])
+  - Allow to specify `identity` of Teamspeak mixer ([#6], [#39]);
+  - Add `sidechain` option to `Mixin` in `Output` ([#70], [#203]).
 
 ### Miscellaneous
 - Server updates:
@@ -29,6 +30,7 @@ All user visible changes to this project will be documented in this file. This p
 - Use FIFO for feeding data into FFmpeg in mixer output ([#199]);
 
 [#6]: /../../issues/6
+[#70]: /../../issues/70
 
 [e1faef9]: /../../commit/e1faef91cc8551505afdf7fc4622c530f9e2c6f6
 [#39]: /../../pull/39
@@ -37,6 +39,7 @@ All user visible changes to this project will be documented in this file. This p
 [#199]: /../../pull/199
 [#200]: /../../pull/200
 [#202]: /../../pull/202
+[#203]: /../../pull/203
 
 
 
@@ -302,7 +305,8 @@ All user visible changes to this project will be documented in this file. This p
         - `InputEndpoint` object, `InputEndpointKind` enum and `EndpointId` scalar ([65f8b86e]).
     - Mutations:
         - `enableRestream` and `disableRestream` ([9e1ac1c7]);
-        - `tuneVolume` and `tuneDelay` ([77d25dd7], [#23]);
+        - `
+        - Volume` and `tuneDelay` ([77d25dd7], [#23]);
         - `mix` argument to `addOutput` ([77d25dd7], [#23]);
         - `import` ([9e1ac1c7]);
         - `removeDvrFile` ([46c85d4d], [#26]).

--- a/components/restreamer/CHANGELOG.md
+++ b/components/restreamer/CHANGELOG.md
@@ -305,8 +305,7 @@ All user visible changes to this project will be documented in this file. This p
         - `InputEndpoint` object, `InputEndpointKind` enum and `EndpointId` scalar ([65f8b86e]).
     - Mutations:
         - `enableRestream` and `disableRestream` ([9e1ac1c7]);
-        - `
-        - Volume` and `tuneDelay` ([77d25dd7], [#23]);
+        - `tuneVolume` and `tuneDelay` ([77d25dd7], [#23]);
         - `mix` argument to `addOutput` ([77d25dd7], [#23]);
         - `import` ([9e1ac1c7]);
         - `removeDvrFile` ([46c85d4d], [#26]).

--- a/components/restreamer/client.graphql.schema.json
+++ b/components/restreamer/client.graphql.schema.json
@@ -880,7 +880,7 @@
           },
           {
             "name": "tuneSidechain",
-            "description": null,
+            "description": "Tunes a `Sidechain` of the specified `Mixin` before mix it into its\n`Output`.\n\n### Result\n\nReturns `true` if a `Sidechain` has been changed, `false` if it has\nthe same value already, or `null` if the specified `Output`\nor `Mixin` doesn't exist.",
             "args": [
               {
                 "name": "restreamId",
@@ -926,7 +926,7 @@
               },
               {
                 "name": "sidechain",
-                "description": "Boolen option where turn sidechain",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -2321,7 +2321,7 @@
           },
           {
             "name": "sidechain",
-            "description": null,
+            "description": "Side-chain audio of `Output` with this `Mixin`.\n\nHelps to automatically control audio level of `Mixin`\nbased on level of `Output`.",
             "args": [],
             "type": {
               "kind": "NON_NULL",

--- a/components/restreamer/client.graphql.schema.json
+++ b/components/restreamer/client.graphql.schema.json
@@ -879,6 +879,75 @@
             "deprecationReason": null
           },
           {
+            "name": "tuneSidechain",
+            "description": null,
+            "args": [
+              {
+                "name": "restreamId",
+                "description": "ID of the `Restream` to tune the the `Mixin` in.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "RestreamId",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "outputId",
+                "description": "ID of the `Output` of the tuned `Mixin`.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "OutputId",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "mixinId",
+                "description": "ID of the tuned `Mixin`.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "MixinId",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "sidechain",
+                "description": "Boolen option where turn sidechain",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "removeDvrFile",
             "description": "Removes the specified recorded file.\n\n### Result\n\nReturns `true` if the specified recorded file was removed, otherwise\n`false` if nothing changes.",
             "args": [
@@ -2244,6 +2313,22 @@
               "ofType": {
                 "kind": "ENUM",
                 "name": "Status",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sidechain",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               }
             },

--- a/components/restreamer/client/api/client.graphql
+++ b/components/restreamer/client/api/client.graphql
@@ -222,6 +222,19 @@ mutation TuneDelay(
         delay: $delay
     )
 }
+mutation TuneSidechain(
+    $restream_id: RestreamId!
+    $output_id: OutputId!
+    $mixin_id: MixinId!
+    $sidechain: Boolean!
+) {
+    tuneSidechain(
+        restreamId: $restream_id
+        outputId: $output_id
+        mixinId: $mixin_id
+        sidechain: $sidechain
+    )
+}
 
 mutation RemoveDvrFile($path: String!) {
     removeDvrFile(path: $path)

--- a/components/restreamer/client/api/client.graphql
+++ b/components/restreamer/client/api/client.graphql
@@ -78,6 +78,7 @@ subscription State {
                     muted
                 }
                 delay
+                sidechain
             }
             enabled
             status

--- a/components/restreamer/client/api/mix.graphql
+++ b/components/restreamer/client/api/mix.graphql
@@ -51,3 +51,17 @@ mutation TuneDelay(
         delay: $delay
     )
 }
+
+mutation TuneSidechain(
+    $restream_id: RestreamId!
+    $output_id: OutputId!
+    $mixin_id: MixinId!
+    $sidechain: Boolean!
+) {
+    tuneSidechain(
+        restreamId: $restream_id
+        outputId: $output_id
+        mixinId: $mixin_id
+        sidechain: $sidechain
+    )
+}

--- a/components/restreamer/client/api/mix.graphql
+++ b/components/restreamer/client/api/mix.graphql
@@ -16,6 +16,7 @@ subscription Output($restreamId: RestreamId!, $outputId: OutputId!) {
                 muted
             }
             delay
+            sidechain
         }
         enabled
         status

--- a/components/restreamer/client/cypress/integration/add_output_multiple_mixin.js
+++ b/components/restreamer/client/cypress/integration/add_output_multiple_mixin.js
@@ -71,6 +71,14 @@ describe('ADD MULTIPLE MIXIN OUTPUT', () => {
     cy.get("button:contains('Add')").should('not.exist');
   });
 
+  it('Only one sidechain checkbox is possible to check through mixins', () => {
+    cy.get("span:contains('Teamspeak Multiple Test')")
+      .parent()
+      .find("input[title='Sidechain']")
+      .first()
+      .click();
+  });
+
   it('Assert', () => {
     cy.get("span:contains('Teamspeak Multiple Test')").should(
       'have.text',
@@ -88,5 +96,9 @@ describe('ADD MULTIPLE MIXIN OUTPUT', () => {
       'have.text',
       'ts://ts.multiple.com/Multiple3'
     );
+    cy.get("span:contains('Teamspeak Multiple Test')")
+      .parent()
+      .find('input[disabled]')
+      .should('have.length', 2);
   });
 });

--- a/components/restreamer/client/cypress/support/commands.js
+++ b/components/restreamer/client/cypress/support/commands.js
@@ -171,7 +171,8 @@ Cypress.Commands.add('importJsonConf', (host) => {
           "mixins": [
             {
               "src": "ts://ts.sameteem.com:9987/AFK\\\\/Muted",
-              "delay": "3s 500ms"
+              "delay": "3s 500ms",
+              "sidechain": true
             },
             {
               "src": "ts://ts.sameteem.com:9987/AFK\\\\/Muted?name=MusicTest",

--- a/components/restreamer/client/package.json
+++ b/components/restreamer/client/package.json
@@ -58,6 +58,6 @@
     "typescript": "^4.6",
     "webpack": "^5.74",
     "webpack-cli": "^4.10",
-    "webpack-dev-server": "^4.9"
+    "webpack-dev-server": "^4.10"
   }
 }

--- a/components/restreamer/client/src/components/AppMix.svelte
+++ b/components/restreamer/client/src/components/AppMix.svelte
@@ -3,10 +3,15 @@
   import { setClient, subscribe } from 'svelte-apollo';
   import Shell from './common/Shell.svelte';
   import Output from './Output.svelte';
-  import { Output as Mix, TuneVolume, TuneDelay } from '../../api/mix.graphql';
+  import {
+    Output as Mix,
+    TuneVolume,
+    TuneDelay,
+    TuneSidechain,
+  } from '../../api/mix.graphql';
   import YoutubePlayer from './common/YoutubePlayer.svelte';
 
-  const mutations = { TuneVolume, TuneDelay };
+  const mutations = { TuneVolume, TuneDelay, TuneSidechain };
 
   const gqlClient = createGraphQlClient(
     '/api-mix',

--- a/components/restreamer/client/src/components/Mixin.svelte
+++ b/components/restreamer/client/src/components/Mixin.svelte
@@ -8,17 +8,20 @@
   export let restream_id;
   export let output_id;
   export let mutations;
+  export let activeSidechainId;
 
   const tuneDelayMutation = mutation(mutations.TuneDelay);
   const tuneSidechainMutation = mutation(mutations.TuneSidechain);
 
   let delay = 0;
   let sidechain = false;
+  let isSidechainDisabled = false;
 
   $: {
     // Trigger Svelte reactivity watching.
     value.delay = value.delay;
     value.sidechain = value.sidechain;
+    isSidechainDisabled = !!activeSidechainId && activeSidechainId !== value.id;
     // Move `sidechain` and `delay` to a separate function to omit triggering this
     // block when they are changed, as we're only interested in `value` changes
     // here.
@@ -101,6 +104,7 @@
         class="uk-checkbox"
         type="checkbox"
         bind:checked={sidechain}
+        disabled={isSidechainDisabled}
         on:change={tuneSidechain}
       />
     </div>

--- a/components/restreamer/client/src/components/Mixin.svelte
+++ b/components/restreamer/client/src/components/Mixin.svelte
@@ -130,11 +130,14 @@
 
     .uk-input
       height: auto
-      width: 40px
+      width: 35px
       padding: 0
       border: none
       margin-top: -2px
       text-align: right
+
+    .fa-link
+      margin-left: 15px
 
     .uk-checkbox
       height: 10px

--- a/components/restreamer/client/src/components/Mixin.svelte
+++ b/components/restreamer/client/src/components/Mixin.svelte
@@ -18,7 +18,7 @@
   $: {
     // Trigger Svelte reactivity watching.
     value.delay = value.delay;
-    value.sidechain = value.sidechain;
+    sidechain = sidechain;
     // Move `sidechain` and `delay` to a separate function to omit triggering this
     // block when they are changed, as we're only interested in `value` changes
     // here.
@@ -31,7 +31,7 @@
   }
 
   function update_sidechain() {
-    sidechain = value.sidechain;
+    sidechain = sidechain;
   }
 
   async function tuneDelay() {

--- a/components/restreamer/client/src/components/Mixin.svelte
+++ b/components/restreamer/client/src/components/Mixin.svelte
@@ -99,7 +99,7 @@
         on:change={tuneDelay}
       />
       <span>s</span>
-      <i class="fad fa-link" title="Sidechain" />
+      <i class="fas fa-link" title="Sidechain" />
       <input
         class="uk-checkbox"
         type="checkbox"

--- a/components/restreamer/client/src/components/Mixin.svelte
+++ b/components/restreamer/client/src/components/Mixin.svelte
@@ -18,7 +18,7 @@
   $: {
     // Trigger Svelte reactivity watching.
     value.delay = value.delay;
-    sidechain = sidechain;
+    value.sidechain = value.sidechain;
     // Move `sidechain` and `delay` to a separate function to omit triggering this
     // block when they are changed, as we're only interested in `value` changes
     // here.
@@ -31,7 +31,7 @@
   }
 
   function update_sidechain() {
-    sidechain = sidechain;
+    sidechain = value.sidechain;
   }
 
   async function tuneDelay() {

--- a/components/restreamer/client/src/components/Mixin.svelte
+++ b/components/restreamer/client/src/components/Mixin.svelte
@@ -87,6 +87,7 @@
       {mutations}
       max={value.src.startsWith('ts://') ? 1000 : 200}
       mixin_id={value.id}
+      title="Mixed audio"
     />
     <div class="options">
       <i class="far fa-clock" title="Delay" />
@@ -97,6 +98,7 @@
         step="0.1"
         bind:value={delay}
         on:change={tuneDelay}
+        title="Delay"
       />
       <span>s</span>
       <i class="fas fa-link" title="Sidechain" />
@@ -106,6 +108,7 @@
         bind:checked={sidechain}
         disabled={isSidechainDisabled}
         on:change={tuneSidechain}
+        title="Sidechain"
       />
     </div>
   </div>

--- a/components/restreamer/client/src/components/Mixin.svelte
+++ b/components/restreamer/client/src/components/Mixin.svelte
@@ -18,14 +18,11 @@
   $: {
     // Trigger Svelte reactivity watching.
     value.delay = value.delay;
-    // Move `volume` and `delay` to a separate function to omit triggering this
+    value.sidechain = value.sidechain;
+    // Move `sidechain` and `delay` to a separate function to omit triggering this
     // block when they are changed, as we're only interested in `value` changes
     // here.
     update_delay();
-  }
-
-  $: {
-    value.sidechain = value.sidechain;
     update_sidechain();
   }
 
@@ -99,7 +96,7 @@
         on:change={tuneDelay}
       />
       <span>s</span>
-      <i class="fae fa-link" title="Sidechain" />
+      <i class="fad fa-link" title="Sidechain" />
       <input
         class="uk-checkbox"
         type="checkbox"
@@ -131,7 +128,7 @@
       text-align: right
 
     .uk-checkbox
-      height: auto
+      height: 10px
       width: 10px
       padding: 0
       margin-top: -2px

--- a/components/restreamer/client/src/components/Mixin.svelte
+++ b/components/restreamer/client/src/components/Mixin.svelte
@@ -10,8 +10,11 @@
   export let mutations;
 
   const tuneDelayMutation = mutation(mutations.TuneDelay);
+  const tuneSidechainMutation = mutation(mutations.TuneSidechain);
 
   let delay = 0;
+  let sidechain = false;
+
   $: {
     // Trigger Svelte reactivity watching.
     value.delay = value.delay;
@@ -21,8 +24,17 @@
     update_delay();
   }
 
+  $: {
+    value.sidechain = value.sidechain;
+    update_sidechain();
+  }
+
   function update_delay() {
     delay = value.delay / 1000;
+  }
+
+  function update_sidechain() {
+    sidechain = value.sidechain;
   }
 
   async function tuneDelay() {
@@ -34,6 +46,20 @@
     };
     try {
       await tuneDelayMutation({ variables });
+    } catch (e) {
+      showError(e.message);
+    }
+  }
+
+  async function tuneSidechain() {
+    const variables = {
+      restream_id,
+      output_id,
+      mixin_id: value.id,
+      sidechain: sidechain,
+    };
+    try {
+      await tuneSidechainMutation({ variables });
     } catch (e) {
       showError(e.message);
     }
@@ -62,7 +88,7 @@
       max={value.src.startsWith('ts://') ? 1000 : 200}
       mixin_id={value.id}
     />
-    <div class="delay">
+    <div class="options">
       <i class="far fa-clock" title="Delay" />
       <input
         class="uk-input"
@@ -73,19 +99,26 @@
         on:change={tuneDelay}
       />
       <span>s</span>
+      <i class="fae fa-link" title="Sidechain" />
+      <input
+        class="uk-checkbox"
+        type="checkbox"
+        bind:checked={sidechain}
+        on:change={tuneSidechain}
+      />
     </div>
   </div>
 </template>
 
 <style lang="stylus">
-  .fa-wave-square, .fa-clock
+  .fa-wave-square, .fa-clock, .fa-link
     font-size: 10px
     color: #d9d9d9
 
   .mixin
     margin-top: 6px
 
-  .delay
+  .options
     padding-left: 17px
     font-size: 10px
 
@@ -94,6 +127,13 @@
       width: 40px
       padding: 0
       border: none
+      margin-top: -2px
+      text-align: right
+
+    .uk-checkbox
+      height: auto
+      width: 10px
+      padding: 0
       margin-top: -2px
       text-align: right
 </style>

--- a/components/restreamer/client/src/components/Mixin.svelte
+++ b/components/restreamer/client/src/components/Mixin.svelte
@@ -89,8 +89,9 @@
       mixin_id={value.id}
       title="Mixed audio"
     />
-    <div class="options">
+    <div class="mixin-options">
       <i class="far fa-clock" title="Delay" />
+      <span>Delay</span>
       <input
         class="uk-input"
         type="number"
@@ -102,6 +103,7 @@
       />
       <span>s</span>
       <i class="fas fa-link" title="Sidechain" />
+      <span>Sidechain</span>
       <input
         class="uk-checkbox"
         type="checkbox"
@@ -122,7 +124,7 @@
   .mixin
     margin-top: 6px
 
-  .options
+  .mixin-options
     padding-left: 17px
     font-size: 10px
 

--- a/components/restreamer/client/src/components/Output.svelte
+++ b/components/restreamer/client/src/components/Output.svelte
@@ -30,6 +30,7 @@
     : undefined;
 
   $: toggleStatusText = value.enabled ? 'Disable' : 'Enable';
+  $: activeSidechainId = value.mixins.find((m) => m.sidechain === true)?.id;
 
   async function toggle() {
     const variables = { restream_id, output_id: value.id };
@@ -187,7 +188,13 @@
           {mutations}
         />
         {#each value.mixins as mixin}
-          <Mixin {restream_id} output_id={value.id} value={mixin} {mutations} />
+          <Mixin
+            {restream_id}
+            output_id={value.id}
+            value={mixin}
+            {mutations}
+            {activeSidechainId}
+          />
         {/each}
       {/if}
     </div>

--- a/components/restreamer/client/src/components/Restream.svelte
+++ b/components/restreamer/client/src/components/Restream.svelte
@@ -13,6 +13,7 @@
     RemoveOutput,
     TuneDelay,
     TuneVolume,
+    TuneSidechain,
     Info,
   } from '../../api/client.graphql';
 
@@ -48,6 +49,7 @@
     RemoveOutput,
     TuneVolume,
     TuneDelay,
+    TuneSidechain,
   };
 
   $: deleteConfirmation = $info.data

--- a/components/restreamer/client/static/dashboard/index.html
+++ b/components/restreamer/client/static/dashboard/index.html
@@ -11,14 +11,14 @@
         rel=icon type=image/png sizes=16x16 href="favicon-16x16.png">
         <link
             rel="stylesheet"
-            href="https://pro.fontawesome.com/releases/v5.14.0/css/all.css"
+            href="https://pro.fontawesome.com/releases/v5.15.4/css/all.css"
         />
         <link rel="stylesheet" href="main.css" />
     </head>
     <body>
         <script
             defer
-            src="https://use.fontawesome.com/releases/v5.14.0/js/all.js"
+            src="https://use.fontawesome.com/releases/v5.15.4/js/all.js"
         ></script>
         <script src="main.js"></script>
     </body>

--- a/components/restreamer/client/static/index.html
+++ b/components/restreamer/client/static/index.html
@@ -10,14 +10,14 @@
         rel=icon type=image/png sizes=16x16 href="favicon-16x16.png">
         <link
             rel="stylesheet"
-            href="https://pro.fontawesome.com/releases/v5.14.0/css/all.css"
+            href="https://pro.fontawesome.com/releases/v5.15.4/css/all.css"
         />
         <link rel="stylesheet" href="main.css" />
     </head>
     <body>
         <script
             defer
-            src="https://use.fontawesome.com/releases/v5.14.0/js/all.js"
+            src="https://use.fontawesome.com/releases/v5.15.4/js/all.js"
         ></script>
         <script src="main.js"></script>
     </body>

--- a/components/restreamer/client/static/mix/index.html
+++ b/components/restreamer/client/static/mix/index.html
@@ -11,14 +11,14 @@
         rel=icon type=image/png sizes=16x16 href="favicon-16x16.png">
         <link
             rel="stylesheet"
-            href="https://pro.fontawesome.com/releases/v5.14.0/css/all.css"
+            href="https://pro.fontawesome.com/releases/v5.15.4/css/all.css"
         />
         <link rel="stylesheet" href="main.css" />
     </head>
     <body>
         <script
             defer
-            src="https://use.fontawesome.com/releases/v5.14.0/js/all.js"
+            src="https://use.fontawesome.com/releases/v5.15.4/js/all.js"
         ></script>
         <script src="main.js"></script>
     </body>

--- a/components/restreamer/client/yarn.lock
+++ b/components/restreamer/client/yarn.lock
@@ -119,10 +119,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jridgewell/trace-mapping@^0.3.7", "@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.14"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz#b231a081d8f66796e475ad588a1ef473112701ed"
-  integrity sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==
+"@jridgewell/trace-mapping@^0.3.14", "@jridgewell/trace-mapping@^0.3.9":
+  version "0.3.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz#aba35c48a38d3fd84b37e66c9c0423f9744f9774"
+  integrity sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
@@ -299,9 +299,9 @@
   integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
 
 "@types/node@*":
-  version "18.7.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.1.tgz#352bee64f93117d867d05f7406642a52685cbca6"
-  integrity sha512-GKX1Qnqxo4S+Z/+Z8KKPLpH282LD7jLHWJcVryOflnsnH+BtSDfieR6ObwBMwpnNws0bUK8GI7z0unQf9bARNQ==
+  version "18.7.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.3.tgz#432c89796eab539b7a30b7b8801a727b585238a4"
+  integrity sha512-LJgzOEwWuMTBxHzgBR/fhhBOWrvBjvO+zPteUgbbuQi80rYIZHrk1mNbRUqPZqSLP2H7Rwt1EFLL/tNLD1Xx/w==
 
 "@types/node@^14.14.31":
   version "14.18.23"
@@ -309,9 +309,9 @@
   integrity sha512-MhbCWN18R4GhO8ewQWAFK4TGQdBpXWByukz7cWyJmXhvRuCIaM/oWytGPqVmDzgEnnaIc9ss6HbU5mUi+vyZPA==
 
 "@types/node@^16.11":
-  version "16.11.47"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.47.tgz#efa9e3e0f72e7aa6a138055dace7437a83d9f91c"
-  integrity sha512-fpP+jk2zJ4VW66+wAMFoBJlx1bxmBKx4DUFf68UHgdGCOuyUTDlLWqsaNPJh7xhNDykyJ9eIzAygilP/4WoN8g==
+  version "16.11.48"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.48.tgz#22d386f32b24fb644940b606ed393b56be7d8686"
+  integrity sha512-Z9r9UWlNeNkYnxybm+1fc0jxUNjZqRekTAr1pG0qdXe9apT9yCiqk1c4VvKQJsFpnchU4+fLl25MabSLA2wxIw==
 
 "@types/prop-types@*":
   version "15.7.5"
@@ -565,16 +565,16 @@
     tslib "^2.3.0"
 
 "@wry/equality@^0.5.0":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.2.tgz#72c8a7a7d884dff30b612f4f8464eba26c080e73"
-  integrity sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.3.tgz#fafebc69561aa2d40340da89fa7dc4b1f6fb7831"
+  integrity sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==
   dependencies:
     tslib "^2.3.0"
 
 "@wry/trie@^0.3.0":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.3.1.tgz#2279b790f15032f8bcea7fc944d27988e5b3b139"
-  integrity sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.3.2.tgz#a06f235dc184bd26396ba456711f69f8c35097e6"
+  integrity sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==
   dependencies:
     tslib "^2.3.0"
 
@@ -945,9 +945,9 @@ camel-case@^3.0.0:
     upper-case "^1.1.1"
 
 caniuse-lite@^1.0.30001370:
-  version "1.0.30001375"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001375.tgz#8e73bc3d1a4c800beb39f3163bf0190d7e5d7672"
-  integrity sha512-kWIMkNzLYxSvnjy0hL8w1NOaWNr2rn39RTAVyIwcw8juu60bZDWiF1/loOYANzjtJmy6qPgNmn38ro5Pygagdw==
+  version "1.0.30001376"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001376.tgz#af2450833e5a06873fbb030a9556ca9461a2736d"
+  integrity sha512-I27WhtOQ3X3v3it9gNs/oTpoE5KpwmqKR5oKPA8M0G7uMXh9Ty81Q904HpKUrM30ei7zfcL5jE7AXefgbOfMig==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1287,9 +1287,9 @@ dashdash@^1.12.0:
     assert-plus "^1.0.0"
 
 dayjs@^1.10.4:
-  version "1.11.4"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.4.tgz#3b3c10ca378140d8917e06ebc13a4922af4f433e"
-  integrity sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g==
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.5.tgz#00e8cc627f231f9499c19b38af49f56dc0ac5e93"
+  integrity sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA==
 
 debug@2.6.9:
   version "2.6.9"
@@ -1397,9 +1397,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.202:
-  version "1.4.213"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.213.tgz#a0d0f535e4fbddc25196c91ff2964b5660932297"
-  integrity sha512-+3DbGHGOCHTVB/Ms63bGqbyC1b8y7Fk86+7ltssB8NQrZtSCvZG6eooSl9U2Q0yw++fL2DpHKOdTU0NVEkFObg==
+  version "1.4.219"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.219.tgz#a7a672304b6aa4f376918d3f63a47f2c3906009a"
+  integrity sha512-zoQJsXOUw0ZA0YxbjkmzBumAJRtr6je5JySuL/bAoFs0DuLiLJ+5FzRF7/ZayihxR2QcewlRZVm5QZdUhwjOgA==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -3777,17 +3777,17 @@ tar@^6.0.2:
     yallist "^4.0.0"
 
 terser-webpack-plugin@^5.1.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz#8033db876dd5875487213e87c627bca323e5ed90"
-  integrity sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==
+  version "5.3.4"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.4.tgz#f4d31e265883d20fda3ca9c0fc6a53f173ae62e3"
+  integrity sha512-SmnkUhBxLDcBfTIeaq+ZqJXLVEyXxSaNcCeSezECdKjfkMrTTnPvapBILylYwyEvHFZAn2cJ8dtiXel5XnfOfQ==
   dependencies:
-    "@jridgewell/trace-mapping" "^0.3.7"
+    "@jridgewell/trace-mapping" "^0.3.14"
     jest-worker "^27.4.5"
     schema-utils "^3.1.1"
     serialize-javascript "^6.0.0"
-    terser "^5.7.2"
+    terser "^5.14.1"
 
-terser@^5.7.2:
+terser@^5.14.1:
   version "5.14.2"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.14.2.tgz#9ac9f22b06994d736174f4091aa368db896f1c10"
   integrity sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==
@@ -3936,9 +3936,9 @@ uikit-icons@^0.5:
     react "^16.11.0"
 
 uikit@^3:
-  version "3.15.2"
-  resolved "https://registry.yarnpkg.com/uikit/-/uikit-3.15.2.tgz#f829316235438600b0ecd7a84558635f02b96454"
-  integrity sha512-4iVYoYDFrY3CWk7mXcnGt8iZPkb/d586rgHJXbelNyQVV94pn++QZSabNr1tnAWwSKORVOCbG5z5hVbQVDvAGQ==
+  version "3.15.3"
+  resolved "https://registry.yarnpkg.com/uikit/-/uikit-3.15.3.tgz#d470646f9d280e420444cc3c1b71b640ec825b0b"
+  integrity sha512-G4sgBuk+qf3hhsaStT9A+bt5NLg1vApdOCS8/FiiSCH4AZS7WRaXVl35EzcBL7UXN6a8Gsb/D3b6K86fjx0xKw==
 
 unique-filename@^1.1.1:
   version "1.1.1"

--- a/components/restreamer/client/yarn.lock
+++ b/components/restreamer/client/yarn.lock
@@ -299,19 +299,19 @@
   integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
 
 "@types/node@*":
-  version "18.7.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.3.tgz#432c89796eab539b7a30b7b8801a727b585238a4"
-  integrity sha512-LJgzOEwWuMTBxHzgBR/fhhBOWrvBjvO+zPteUgbbuQi80rYIZHrk1mNbRUqPZqSLP2H7Rwt1EFLL/tNLD1Xx/w==
+  version "18.7.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.5.tgz#f1c1d4b7d8231c0278962347163656f9c36f3e83"
+  integrity sha512-NcKK6Ts+9LqdHJaW6HQmgr7dT/i3GOHG+pt6BiWv++5SnjtRd4NXeiuN2kA153SjhXPR/AhHIPHPbrsbpUVOww==
 
 "@types/node@^14.14.31":
-  version "14.18.23"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.23.tgz#70f5f20b0b1b38f696848c1d3647bb95694e615e"
-  integrity sha512-MhbCWN18R4GhO8ewQWAFK4TGQdBpXWByukz7cWyJmXhvRuCIaM/oWytGPqVmDzgEnnaIc9ss6HbU5mUi+vyZPA==
+  version "14.18.24"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.24.tgz#406b220dc748947e1959d8a38a75979e87166704"
+  integrity sha512-aJdn8XErcSrfr7k8ZDDfU6/2OgjZcB2Fu9d+ESK8D7Oa5mtsv8Fa8GpcwTA0v60kuZBaalKPzuzun4Ov1YWO/w==
 
 "@types/node@^16.11":
-  version "16.11.48"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.48.tgz#22d386f32b24fb644940b606ed393b56be7d8686"
-  integrity sha512-Z9r9UWlNeNkYnxybm+1fc0jxUNjZqRekTAr1pG0qdXe9apT9yCiqk1c4VvKQJsFpnchU4+fLl25MabSLA2wxIw==
+  version "16.11.49"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.49.tgz#560b1ea774b61e19a89c3fc72d2dcaa3863f38b2"
+  integrity sha512-Abq9fBviLV93OiXMu+f6r0elxCzRwc0RC5f99cU892uBITL44pTvgvEqlRlPRi8EGcO1z7Cp8A4d0s/p3J/+Nw==
 
 "@types/prop-types@*":
   version "15.7.5"
@@ -4085,7 +4085,7 @@ webpack-dev-middleware@^5.3.1:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@^4.9:
+webpack-dev-server@^4.10:
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.10.0.tgz#de270d0009eba050546912be90116e7fd740a9ca"
   integrity sha512-7dezwAs+k6yXVFZ+MaL8VnE+APobiO3zvpp3rBHe/HmWQ+avwh0Q3d0xxacOiBybZZ3syTZw9HXzpa3YNbAZDQ==

--- a/components/restreamer/mix.graphql.schema.json
+++ b/components/restreamer/mix.graphql.schema.json
@@ -351,7 +351,7 @@
           },
           {
             "name": "sidechain",
-            "description": null,
+            "description": "Side-chain audio of `Output` with this `Mixin`.\n\nHelps to automatically control audio level of `Mixin`\nbased on level of `Output`.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -538,7 +538,7 @@
           },
           {
             "name": "tuneSidechain",
-            "description": null,
+            "description": "Tunes a the specified [`Mixin.sidechain`] in this [`State`]",
             "args": [
               {
                 "name": "restreamId",

--- a/components/restreamer/mix.graphql.schema.json
+++ b/components/restreamer/mix.graphql.schema.json
@@ -348,6 +348,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "sidechain",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -506,6 +522,75 @@
                   "ofType": {
                     "kind": "SCALAR",
                     "name": "Delay",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tuneSidechain",
+            "description": null,
+            "args": [
+              {
+                "name": "restreamId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "RestreamId",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "outputId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "OutputId",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "mixinId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "MixinId",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "sidechain",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   }
                 },

--- a/components/restreamer/src/api/graphql/client.rs
+++ b/components/restreamer/src/api/graphql/client.rs
@@ -665,6 +665,15 @@ impl MutationsRoot {
             .state()
             .tune_delay(restream_id, output_id, mixin_id, delay)
     }
+
+    /// Tunes a `Sidechain` of the specified `Mixin` before mix it into its
+    /// `Output`.
+    ///
+    /// ### Result
+    ///
+    /// Returns `true` if a `Sidechain` has been changed, `false` if it has
+    /// the same value already, or `null` if the specified `Output`
+    /// or `Mixin` doesn't exist.
     fn tune_sidechain(
         #[graphql(
             description = "ID of the `Restream` to tune the the `Mixin` in."
@@ -673,7 +682,6 @@ impl MutationsRoot {
         #[graphql(description = "ID of the `Output` of the tuned `Mixin`.")]
         output_id: OutputId,
         #[graphql(description = "ID of the tuned `Mixin`.")] mixin_id: MixinId,
-        #[graphql(description = "Boolen option where turn sidechain")]
         sidechain: bool,
         context: &Context,
     ) -> Option<bool> {

--- a/components/restreamer/src/api/graphql/client.rs
+++ b/components/restreamer/src/api/graphql/client.rs
@@ -440,6 +440,7 @@ impl MutationsRoot {
                 .map(|src| {
                     let delay;
                     let volume;
+                    let sidechain;
                     if let Some(orig_mixin) =
                         existing_output.as_ref().and_then(|val| {
                             val.mixins.iter().find(|val| val.src == src)
@@ -447,14 +448,21 @@ impl MutationsRoot {
                     {
                         volume = orig_mixin.volume.export();
                         delay = orig_mixin.delay;
+                        sidechain = orig_mixin.sidechain;
                     } else {
                         volume = Volume::ORIGIN.export();
                         delay = (src.scheme() == "ts")
                             .then(|| Delay::from_millis(3500))
                             .flatten()
                             .unwrap_or_default();
+                        sidechain = false;
                     }
-                    spec::v1::Mixin { src, volume, delay }
+                    spec::v1::Mixin {
+                        src,
+                        volume,
+                        delay,
+                        sidechain,
+                    }
                 })
                 .collect(),
             enabled: false,
@@ -656,6 +664,25 @@ impl MutationsRoot {
         context
             .state()
             .tune_delay(restream_id, output_id, mixin_id, delay)
+    }
+    fn tune_sidechain(
+        #[graphql(
+            description = "ID of the `Restream` to tune the the `Mixin` in."
+        )]
+        restream_id: RestreamId,
+        #[graphql(description = "ID of the `Output` of the tuned `Mixin`.")]
+        output_id: OutputId,
+        #[graphql(description = "ID of the tuned `Mixin`.")] mixin_id: MixinId,
+        #[graphql(description = "Boolen option where turn sidechain")]
+        sidechain: bool,
+        context: &Context,
+    ) -> Option<bool> {
+        context.state().tune_sidechain(
+            restream_id,
+            output_id,
+            mixin_id,
+            sidechain,
+        )
     }
 
     /// Removes the specified recorded file.

--- a/components/restreamer/src/api/graphql/mix.rs
+++ b/components/restreamer/src/api/graphql/mix.rs
@@ -60,6 +60,8 @@ impl MutationsRoot {
             .state()
             .tune_delay(restream_id, output_id, mixin_id, delay)
     }
+
+    /// Tunes a `Sidechain` of the specified `Mixin` before mix it into its
     fn tune_sidechain(
         restream_id: RestreamId,
         output_id: OutputId,

--- a/components/restreamer/src/api/graphql/mix.rs
+++ b/components/restreamer/src/api/graphql/mix.rs
@@ -60,6 +60,20 @@ impl MutationsRoot {
             .state()
             .tune_delay(restream_id, output_id, mixin_id, delay)
     }
+    fn tune_sidechain(
+        restream_id: RestreamId,
+        output_id: OutputId,
+        mixin_id: MixinId,
+        sidechain: bool,
+        context: &Context,
+    ) -> Option<bool> {
+        context.state().tune_sidechain(
+            restream_id,
+            output_id,
+            mixin_id,
+            sidechain,
+        )
+    }
 }
 
 /// Root of all [GraphQL queries][1] in the [`Schema`].

--- a/components/restreamer/src/api/graphql/mix.rs
+++ b/components/restreamer/src/api/graphql/mix.rs
@@ -61,7 +61,7 @@ impl MutationsRoot {
             .tune_delay(restream_id, output_id, mixin_id, delay)
     }
 
-    /// Tunes a `Sidechain` of the specified `Mixin` before mix it into its
+    /// Tunes a the specified [`Mixin.sidechain`] in this [`State`]
     fn tune_sidechain(
         restream_id: RestreamId,
         output_id: OutputId,

--- a/components/restreamer/src/ffmpeg/mixing_restreamer.rs
+++ b/components/restreamer/src/ffmpeg/mixing_restreamer.rs
@@ -242,14 +242,14 @@ impl MixingRestreamer {
                 port = mixin.zmq_port,
             ));
         }
-        let with_sidechain = true;
-        if with_sidechain {
+
+        if let Some(m) = self.mixins.iter().find(|m| m.sidechain) {
             filter_complex.push(
                 format!("[{mixin_id}]asplit=2[sc][mix];[{orig_id}][sc]sidechaincompress=level_in=2:\
                 threshold=0.01:ratio=10:attack=10:release=1500[compr];\
                 [compr][mix]amix[out]",
-                orig_id=self.id,
-                mixin_id=self.mixins.iter().nth(0).unwrap().id.to_string(),
+                        orig_id=self.id,
+                        mixin_id=m.id.to_string(),
                 )
             );
         } else {
@@ -507,7 +507,9 @@ impl Mixin {
     #[inline]
     #[must_use]
     pub fn needs_restart(&self, actual: &Self) -> bool {
-        self.url != actual.url || self.delay != actual.delay
+        self.url != actual.url
+            || self.delay != actual.delay
+            || self.sidechain != actual.sidechain
     }
 
     /// [FIFO] path where stream captures from the [TeamSpeak] server.

--- a/components/restreamer/src/ffmpeg/mixing_restreamer.rs
+++ b/components/restreamer/src/ffmpeg/mixing_restreamer.rs
@@ -428,6 +428,9 @@ pub struct Mixin {
     /// [`Volume`] rate to mix an audio of this [`Mixin`]'s live stream with.
     pub volume: Volume,
 
+    /// [`Sidechain`] audio of this [`Mixin`]'s with live stream.
+    pub sidechain: bool,
+
     /// [ZeroMQ] port of a spawned [FFmpeg] process listening to a real-time
     /// filter updates of this [`Mixin`]'s live stream during mixing process.
     ///
@@ -442,8 +445,6 @@ pub struct Mixin {
     /// [TeamSpeak]: https://teamspeak.com
     /// [FIFO]: https://www.unix.com/man-page/linux/7/fifo/
     stdin: Option<Arc<Mutex<teamspeak::Input>>>,
-
-    sidechain: bool,
 }
 
 impl Mixin {
@@ -509,10 +510,10 @@ impl Mixin {
             id: state.id,
             url: state.src.clone(),
             delay: state.delay,
+            sidechain: state.sidechain,
             volume: state.volume.clone(),
             zmq_port: new_unique_zmq_port(),
             stdin,
-            sidechain: state.sidechain,
         }
     }
 

--- a/components/restreamer/src/ffmpeg/mixing_restreamer.rs
+++ b/components/restreamer/src/ffmpeg/mixing_restreamer.rs
@@ -428,7 +428,9 @@ pub struct Mixin {
     /// [`Volume`] rate to mix an audio of this [`Mixin`]'s live stream with.
     pub volume: Volume,
 
-    /// [`Sidechain`] audio of this [`Mixin`]'s with live stream.
+    /// Apply [sidechain] audio filter of this [`Mixin`]'s with live stream.
+    ///
+    /// [sidechain]: https://ffmpeg.org/ffmpeg-filters.html#sidechaincompress
     pub sidechain: bool,
 
     /// [ZeroMQ] port of a spawned [FFmpeg] process listening to a real-time

--- a/components/restreamer/src/ffmpeg/mixing_restreamer.rs
+++ b/components/restreamer/src/ffmpeg/mixing_restreamer.rs
@@ -266,10 +266,10 @@ impl MixingRestreamer {
             ));
             // Replace Mixin Id for sidechain with `mix` value
             if let Some(elem) =
-                mixin_ids.iter_mut().find(|x| *x == sidechain_mixin_id)
+                mixin_ids.iter_mut().find(|x| **x == sidechain_mixin_id)
             {
-                *elem = "mix".to_string()
-            }
+                *elem = "mix".to_string();
+            };
 
             // Replace Origin Audio Id with side-chained version
             orig_id = "compr".to_string();

--- a/components/restreamer/src/ffmpeg/mixing_restreamer.rs
+++ b/components/restreamer/src/ffmpeg/mixing_restreamer.rs
@@ -425,6 +425,8 @@ pub struct Mixin {
     /// [TeamSpeak]: https://teamspeak.com
     /// [FIFO]: https://www.unix.com/man-page/linux/7/fifo/
     stdin: Option<Arc<Mutex<teamspeak::Input>>>,
+
+    sidechain: bool,
 }
 
 impl Mixin {
@@ -493,6 +495,7 @@ impl Mixin {
             volume: state.volume.clone(),
             zmq_port: new_unique_zmq_port(),
             stdin,
+            sidechain: state.sidechain,
         }
     }
 

--- a/components/restreamer/src/ffmpeg/mixing_restreamer.rs
+++ b/components/restreamer/src/ffmpeg/mixing_restreamer.rs
@@ -268,7 +268,7 @@ impl MixingRestreamer {
             if let Some(elem) =
                 mixin_ids.iter_mut().find(|x| **x == sidechain_mixin_id)
             {
-                *elem = "mix".to_string();
+                "mix".clone_into(elem);
             };
 
             // Replace Origin Audio Id with side-chained version

--- a/components/restreamer/src/spec/v1.rs
+++ b/components/restreamer/src/spec/v1.rs
@@ -303,6 +303,7 @@ impl Output {
         if !mixins.is_empty() {
             let mut unique = HashSet::with_capacity(mixins.len());
             let mut ts_count: u8 = 0;
+            let mut has_sidechain = false;
             for m in &mixins {
                 if let Some(src) = unique.replace(&m.src) {
                     return Err(D::Error::custom(format!(
@@ -319,6 +320,16 @@ impl Output {
                             m.src,
                         )));
                     }
+                }
+                if m.sidechain {
+                    if has_sidechain {
+                        return Err(D::Error::custom(format!(
+                            "Only one Mixin.sidechain is allowed \
+                            in Output.mixins: {}",
+                            m.src
+                        )));
+                    }
+                    has_sidechain = true;
                 }
             }
         }

--- a/components/restreamer/src/spec/v1.rs
+++ b/components/restreamer/src/spec/v1.rs
@@ -355,7 +355,7 @@ pub struct Mixin {
 
     /// Set that this [`Mixin`] should be side-chained with an
     /// [`Output`].
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub sidechain: bool,
 }
 

--- a/components/restreamer/src/spec/v1.rs
+++ b/components/restreamer/src/spec/v1.rs
@@ -342,6 +342,8 @@ pub struct Mixin {
     #[serde(default, skip_serializing_if = "state::Delay::is_zero")]
     pub delay: state::Delay,
 
+    /// Set that this [`Mixin`] should be side-chained with an
+    /// [`Output`].
     #[serde(default)]
     pub sidechain: bool,
 }

--- a/components/restreamer/src/spec/v1.rs
+++ b/components/restreamer/src/spec/v1.rs
@@ -341,6 +341,9 @@ pub struct Mixin {
     /// [`Output`].
     #[serde(default, skip_serializing_if = "state::Delay::is_zero")]
     pub delay: state::Delay,
+
+    #[serde(default)]
+    pub sidechain: bool,
 }
 
 /// Shareable specification of [`state::Volume`].

--- a/components/restreamer/src/state.rs
+++ b/components/restreamer/src/state.rs
@@ -760,6 +760,13 @@ impl State {
         mixin.delay = delay;
         Some(true)
     }
+
+    /// Tunes a [`Sidechain`] of the specified [`Mixin`] in this [`State`].
+    ///
+    /// Returns `true` if a [`Sidechain`] has been changed, or `false` if it has the
+    /// same value already.
+    ///
+    /// Returns [`None`] if no such [`Restream`]/[`Output`]/[`Mixin`] exists.
     #[must_use]
     pub fn tune_sidechain(
         &self,
@@ -2025,6 +2032,10 @@ pub struct Mixin {
     #[serde(skip)]
     pub status: Status,
 
+    /// Side-chain audio of `Output` with this `Mixin`.
+    ///
+    /// Helps to automatically control audio level of `Mixin`
+    /// based on level of `Output`.
     #[serde(default)]
     pub sidechain: bool,
 }

--- a/components/restreamer/src/state.rs
+++ b/components/restreamer/src/state.rs
@@ -761,10 +761,10 @@ impl State {
         Some(true)
     }
 
-    /// Tunes a [`Sidechain`] of the specified [`Mixin`] in this [`State`].
+    /// Tunes a the specified [`Mixin.sidechain`] in this [`State`].
     ///
-    /// Returns `true` if a [`Sidechain`] has been changed, or `false` if it has the
-    /// same value already.
+    /// Returns `true` if a [`Mixin.sidechain`] has been changed, or `false`
+    /// if it has the same value already.
     ///
     /// Returns [`None`] if no such [`Restream`]/[`Output`]/[`Mixin`] exists.
     #[must_use]
@@ -2036,7 +2036,7 @@ pub struct Mixin {
     ///
     /// Helps to automatically control audio level of `Mixin`
     /// based on level of `Output`.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub sidechain: bool,
 }
 


### PR DESCRIPTION
Feature allows applying sidechain ffmpeg filter for specified `Mixin`. It is basically mixing Origin Audio and selected Mixin Audio. It helps to automatically control audio level of `Mixin` based on level of `Output`. More details about this filter could find in [ffmpeg docs](https://ffmpeg.org/ffmpeg-filters.html#sidechaincompress).

### UI look
Single Mixin
![image](https://user-images.githubusercontent.com/1163493/184829365-3d90564a-20cb-4376-99dd-a8bf5d16820a.png)

Multiple Mixins per output. Only one sidechain is possible to set.
![image](https://user-images.githubusercontent.com/1163493/184829549-a1c78b30-fa01-4380-a64a-bbaf69a9cf19.png)
