### PR TITLE
Change Delay without restart FFmpeg in Restreamer Mixin

### DIFF
--- a/components/restreamer/CHANGELOG.md
+++ b/components/restreamer/CHANGELOG.md
@@ -14,15 +14,19 @@ All user visible changes to this project will be documented in this file. This p
 ### Added
 
 - Web UI:
-  - Allow to use multiple Teamspeak mixers per output ([#199]);
-  - Allow to specify `identity` of Teamspeak mixer ([#6], [#39]);
+  - Allow to set multiple Teamspeak mixers per output ([#199]);
+  - Allow to specify `identity` in Teamspeak `Mixin` ([#6], [#39]);
   - Add `sidechain` option to `Mixin` in `Output` ([#70], [#203]).
 
-- Smooth Delay change in Restreamer Mixin ([#23], [#212]).
+- GraphQL API:
+  - Types:
+    - Add `sidechain` scalar to `Mixin` ([#203]);
+
+- Smooth `Delay` change in Restreamer Mixin ([#23], [#212]).
 
 ### Fixed
 - 'Gray screen' appears during switching from 'main' to 'backup' endpoint ([#164], [#204]);
-- Fast delay adjust makes blaming icon constantly ([#116]).
+- Fast `Delay` adjust makes blaming icon constantly ([#116]).
 
 ### Miscellaneous
 - Server updates:

--- a/components/restreamer/CHANGELOG.md
+++ b/components/restreamer/CHANGELOG.md
@@ -18,10 +18,11 @@ All user visible changes to this project will be documented in this file. This p
   - Allow to specify `identity` of Teamspeak mixer ([#6], [#39]);
   - Add `sidechain` option to `Mixin` in `Output` ([#70], [#203]).
 
+- Smooth Delay change in Restreamer Mixin ([#23], [#212]).
 
 ### Fixed
-- 'Gray screen' appears during switching from 'main' to 'backup' endpoint ([#164], [#204]).
-
+- 'Gray screen' appears during switching from 'main' to 'backup' endpoint ([#164], [#204]);
+- Fast delay adjust makes blaming icon constantly ([#116]).
 
 ### Miscellaneous
 - Server updates:
@@ -37,7 +38,9 @@ All user visible changes to this project will be documented in this file. This p
 
 
 [#6]: /../../issues/6
+[#23]: /../../issues/23
 [#70]: /../../issues/70
+[#116]: /../../issues/116
 [#164]: /../../issues/164
 
 [e1faef9]: /../../commit/e1faef91cc8551505afdf7fc4622c530f9e2c6f6
@@ -49,6 +52,7 @@ All user visible changes to this project will be documented in this file. This p
 [#202]: /../../pull/202
 [#203]: /../../pull/203
 [#204]: /../../pull/204
+[#212]: /../../pull/212
 
 
 

--- a/components/restreamer/client/cypress/integration/check_streaming_state.js
+++ b/components/restreamer/client/cypress/integration/check_streaming_state.js
@@ -46,6 +46,15 @@ describe('CHECK STREAMING STATE', () => {
     cy.wait(6000);
   });
 
+  it('5 Select Delay should not restart', () => {
+    cy.get('[data-testid=Teamspeak]')
+      .parent()
+      .find("input[title='Delay']")
+      .first()
+      .type('5.5')
+      .trigger('change');
+  });
+
   it('5 Assert Started', () => {
     cy.checkStartedAllStated();
   });

--- a/components/restreamer/src/ffmpeg/mixing_restreamer.rs
+++ b/components/restreamer/src/ffmpeg/mixing_restreamer.rs
@@ -262,9 +262,10 @@ impl MixingRestreamer {
                 "[{sidechain_mixin_id}]asplit=2[sc][mix];\
                  [{orig_id}][sc]sidechaincompress=\
                                     level_in=2\
-                                    :threshold=0.01\
+                                    :threshold=0.05\
                                     :ratio=10\
                                     :attack=10\
+                                    :knee=4\
                                     :release=1500[compr]"
             ));
             // Replace Mixin Id for sidechain with `mix` value


### PR DESCRIPTION
After @deiwo fixed FFmpeg https://github.com/FFmpeg/FFmpeg/commit/4b40e20ce922268bc3c79e9068c11a92efae04a0 becomes possible to change delay without restart of FFmpeg.