### PR TITLE
Fix regex issue caused Safari fail on loading page

### DIFF
--- a/components/restreamer/client/src/components/Playlist.svelte
+++ b/components/restreamer/client/src/components/Playlist.svelte
@@ -51,9 +51,14 @@
   }
 
   function fetchFolderId(id) {
-    return isFullGDrivePath(id)
-      ? id.match(/(?<folderId>(?<=folders\/)[\S]+)/)?.groups?.folderId
-      : id;
+    if (isFullGDrivePath(id)) {
+      const result = id.match(/folders\/([^\/]+)/);
+      if (result) {
+        return result[1];
+      }
+    }
+
+    return id;
   }
 
   function handleInputFolderId(event) {

--- a/components/restreamer/client/src/modals/RestreamModal.svelte
+++ b/components/restreamer/client/src/modals/RestreamModal.svelte
@@ -155,9 +155,14 @@
   };
 
   const fetchFileId = (id) => {
-    return isFullGDrivePath(id)
-      ? id.match(/(?<fileId>(?<=file\/d\/).{33})\//)?.groups?.fileId
-      : id;
+    if (isFullGDrivePath(id)) {
+      const result = id.match(/file\/d\/([^\/]+)/);
+      if (result) {
+        return result[1];
+      }
+    }
+
+    return id;
   };
 
   const handleInputFileId = (event) => {


### PR DESCRIPTION
Latest version of Safari refuse to load main page due to some unknown regex. 
Here is the detailed explanation of the issue: [https://stackoverflow.com/questions/51568821/works-in-chrome-but-breaks-in-safari-invalid-regular-expression-invalid-group](https://stackoverflow.com/questions/51568821/works-in-chrome-but-breaks-in-safari-invalid-regular-expression-invalid-group)

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- Bug fix: Fixes a regex issue that was causing the main page to fail to load on the latest version of Safari.

> "Safari, oh Safari, why won't you load?
> Regex issues abound, but fear not, we've strode
> Into the code, and with a few changes made
> Your browsing experience will no longer fade."
<!-- end of auto-generated comment: release notes by openai -->