### PR TITLE
Refactor deploy script

### DIFF
--- a/components/restreamer/CHANGELOG.md
+++ b/components/restreamer/CHANGELOG.md
@@ -12,6 +12,8 @@ All user visible changes to this project will be documented in this file. This p
 - Deploy:
     - Open ports 80, 8000 and 1935 ports by default ([#267]);
     - Add Jaeger envs: EPHYR_RESTREAMER_JAEGER_AGENT_IP, EPHYR_RESTREAMER_JAEGER_AGENT_PORT ([#284]);
+    - Add `ALLOWED_IPS` option to set allowed IP addresses to access server ([#352]);
+    - Add `CLEAR_STATE_ON_RESTART` option that clears state after restart if set([#352]);
 - CI:
   - Configure dependabot ([#244]);
 - Dashboard:
@@ -26,7 +28,7 @@ All user visible changes to this project will be documented in this file. This p
   - Video playback for file Input ([#166], [#297]);
   - Display stream info for file-backup endpoint ([#322]);
   - Auto conversion of Google Drive links to Id's ([#313], [#321]);
-  - Ability to re-order input endpoints ([#345]);
+  - Ability to re-order input endpoints ([#346], [#345]);
 - General
   - Show number of cores on server instance ([#227], [#254]);
   - Google Drive API key to Ephyr server ([#168], [#297]);
@@ -62,6 +64,7 @@ All user visible changes to this project will be documented in this file. This p
 [#260]: /../../issues/260
 [#313]: /../../issues/313
 [#323]: /../../issues/323
+[#346]: /../../issues/346
 
 [#239]: /../../pull/239
 [#244]: /../../pull/244
@@ -77,6 +80,7 @@ All user visible changes to this project will be documented in this file. This p
 [#322]: /../../pull/322
 [#341]: /../../pull/341
 [#345]: /../../pull/345
+[#352]: /../../pull/352
 
 
 


### PR DESCRIPTION
Add options to deploy script:
- `CLEAR_STATE_ON_RESTART`: Clear `state.json` each restart of Ephyr-restreamer. Default is '0'.
- `ALLOWED_IPS`: Set allowed IP addresses to access server. Default is '*'.


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- Refactor: Simplified the deployment script, improved error handling, and added more comments to make the script more readable.
- Documentation: Updated the README.md file to reflect the changes made to the deployment script.

> "Deploy script refactored with care,
> Errors handled with grace so rare.
> Readability improved, code simplified,
> Deployment process now unified."
<!-- end of auto-generated comment: release notes by openai -->