### PR TITLE
Update ffmpeg to 6.0

### DIFF
--- a/components/restreamer/CHANGELOG.md
+++ b/components/restreamer/CHANGELOG.md
@@ -12,7 +12,12 @@ All user visible changes to this project will be documented in this file. This p
 ### Fixed
 - Proper kill SRS server during restart ([#374]);
 
+### Miscellaneous
+- Update [FFmpeg] to 6.0  ([#375]);
+
+
 [#374]: /../../pull/374
+[#375]: /../../pull/375
 
 
 

--- a/components/restreamer/Dockerfile
+++ b/components/restreamer/Dockerfile
@@ -2,8 +2,8 @@
 # Stage 'build-ephyr' builds Ephyr for the final stage.
 #
 
-# https://github.com/jrottenberg/ffmpeg/blob/master/docker-images/5.1/ubuntu2004/Dockerfile
-FROM jrottenberg/ffmpeg:5.1-ubuntu2004 AS build-ephyr
+# https://github.com/jrottenberg/ffmpeg/blob/master/docker-images/6.0/ubuntu2004/Dockerfile
+FROM jrottenberg/ffmpeg:6.0-ubuntu2004 AS build-ephyr
 
 
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

### Release Notes

- **Chore:** Update to FFmpeg 6.0 in Dockerfile and CHANGELOG.md.

> "FFmpeg six-point-oh,
> Restreamer's now good to go.
> Code's updated, all is fine,
> Ready for the next big climb."
<!-- end of auto-generated comment: release notes by openai -->