### PR TITLE
Restore visibility of sound mixer for parent restream + fix import errors + new dashboard APIs

### DIFF
--- a/.github/workflows/openai-review.yml
+++ b/.github/workflows/openai-review.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           debug: false
           review_comment_lgtm: false
-          summary_only: true
+          summarize: true
           path_filters: |
             !**/*.lock

--- a/components/restreamer/CHANGELOG.md
+++ b/components/restreamer/CHANGELOG.md
@@ -11,15 +11,22 @@ All user visible changes to this project will be documented in this file. This p
 
 ### Fixed
 - Proper kill SRS server during restart ([#374]);
+- Display download status of file from playlist ([#222],[#348])
+- Verify that files from Google Drive are completely downloaded ([#192], [#348])
+- Playlist api ([#178], [#348])
+- Playlist status component ([#343], [#348])
 
 ### Miscellaneous
 - Update [FFmpeg] to 6.0  ([#375]);
 
+[#222]: /../../issues/222
+[#192]: /../../issues/192
+[#178]: /../../issues/178
+[#343]: /../../issues/343
 
+[#348]: /../../pull/348
 [#374]: /../../pull/374
 [#375]: /../../pull/375
-
-
 
 
 

--- a/components/restreamer/CHANGELOG.md
+++ b/components/restreamer/CHANGELOG.md
@@ -14,7 +14,15 @@ All user visible changes to this project will be documented in this file. This p
 - Display download status of file from playlist ([#222],[#348])
 - Verify that files from Google Drive are completely downloaded ([#192], [#348])
 - Playlist api ([#178], [#348])
-- Playlist status component ([#343], [#348])
+- Export/import of playlist ([#386])
+- Export/Import of file backup ([#386])
+
+### Added
+- Dashboard:
+  - Remove all clients ([#386])
+  - Star/Stop playing file ([#386])
+- Playlist
+  - Status component ([#343], [#348])
 
 ### Miscellaneous
 - Update [FFmpeg] to 6.0  ([#375]);
@@ -27,6 +35,7 @@ All user visible changes to this project will be documented in this file. This p
 [#348]: /../../pull/348
 [#374]: /../../pull/374
 [#375]: /../../pull/375
+[#386]: /../../pull/386
 
 
 

--- a/components/restreamer/client.graphql.schema.json
+++ b/components/restreamer/client.graphql.schema.json
@@ -12,8 +12,389 @@
     },
     "types": [
       {
+        "kind": "SCALAR",
+        "name": "Delay",
+        "description": "Delay of a [`Mixin`] being mixed with an [`Output`].\n\n[`Mixin`]: crate::state::Mixin\n[`Output`]: crate::state::Output",
+        "specifiedByUrl": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Label",
+        "description": "Label of a [`Restream`] or an [`Output`].\n\n[`Restream`]: crate::state::Restream\n[`Output`]: crate::state::Output",
+        "specifiedByUrl": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
-        "name": "__EnumValue",
+        "name": "Input",
+        "description": "Upstream source that a `Restream` receives a live stream from.",
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": "Unique ID of this `Input`.\n\nOnce assigned, it never changes.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "InputId",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "key",
+            "description": "Key of this `Input` to expose its `InputEndpoint`s with for accepting\nand serving a live stream.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "InputKey",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endpoints",
+            "description": "Endpoints of this `Input` serving a live stream for `Output`s and\nclients.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "InputEndpoint",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "src",
+            "description": "Source to pull a live stream from.\n\nIf specified, then this `Input` will pull a live stream from it (pull\nkind), otherwise this `Input` will await a live stream to be pushed\n(push kind).",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "InputSrc",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "enabled",
+            "description": "Indicator whether this `Input` is enabled, so is allowed to receive a\nlive stream from its upstream sources.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "InputSrcUrl",
+        "description": "[`Url`] of a [`RemoteInputSrc`].\n\nOnly the following URLs are allowed at the moment:\n- [RTMP] URL (starting with `rtmp://` or `rtmps://` scheme and having a\n  host);\n- [HLS] URL (starting with `http://` or `https://` scheme, having a host,\n  and with `.m3u8` extension in its path).\n\n[HLS]: https://en.wikipedia.org/wiki/HTTP_Live_Streaming\n[RTMP]: https://en.wikipedia.org/wiki/Real-Time_Messaging_Protocol",
+        "specifiedByUrl": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Float",
+        "description": null,
+        "specifiedByUrl": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "__Schema",
+        "description": null,
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "types",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "queryType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mutationType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "__Type",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "subscriptionType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "__Type",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "directives",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Directive",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "InputEndpoint",
+        "description": "Endpoint of an `Input` serving a live stream for `Output`s and clients.",
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": "Unique ID of this `InputEndpoint`.\n\nOnce assigned, it never changes.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "EndpointId",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": "Kind of this `InputEndpoint`.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "InputEndpointKind",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "label",
+            "description": "User defined label for each Endpoint",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Label",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fileId",
+            "description": "If the endpoint is of type FILE, then this contains\nthe file ID that is in the [`State::files`]\n\n[`State::files`]: crate::state::State::files",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "FileId",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": "`Status` of this `InputEndpoint` indicating whether it actually serves a\nlive stream ready to be consumed by `Output`s and clients.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "Status",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "streamStat",
+            "description": "Corresponding stream info",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "StreamStatistics",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Url",
+        "description": null,
+        "specifiedByUrl": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "PlaylistId",
+        "description": "ID of a `Playlist`.",
+        "specifiedByUrl": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "String",
+        "description": null,
+        "specifiedByUrl": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "__Field",
         "description": null,
         "specifiedByUrl": null,
         "fields": [
@@ -46,6 +427,46 @@
             "deprecationReason": null
           },
           {
+            "name": "args",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "isDeprecated",
             "description": null,
             "args": [],
@@ -68,6 +489,651 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Mixin",
+        "description": "Additional source for an `Output` to be mixed with before re-streaming to\nthe destination.",
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": "Unique ID of this `Mixin`.\n\nOnce assigned, it never changes.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "MixinId",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "src",
+            "description": "URL of the source to be mixed with an `Output`.\n\nAt the moment, only [TeamSpeak] is supported.\n\n[TeamSpeak]: https://teamspeak.com",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "MixinSrcUrl",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "volume",
+            "description": "Volume rate of this `Mixin`'s audio tracks to mix them with.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Volume",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "delay",
+            "description": "Delay that this `Mixin` should wait before being mixed with an `Output`.\n\nVery useful to fix de-synchronization issues and correct timings between\na `Mixin` and its `Output`.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Delay",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": "`Status` of this `Mixin` indicating whether it provides an actual media\nstream to be mixed with its `Output`.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "Status",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sidechain",
+            "description": "Side-chain audio of `Output` with this `Mixin`.\n\nHelps to automatically control audio level of `Mixin`\nbased on level of `Output`.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "InputId",
+        "description": "ID of an `Input`.",
+        "specifiedByUrl": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Info",
+        "description": "Information about parameters that this server operates with.",
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "publicHost",
+            "description": "Host that this server is reachable via in public.\n\nUse it for constructing URLs to this server.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": "Title of the server",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleteConfirmation",
+            "description": "Whether do we need to confirm deletion of inputs and outputs",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "enableConfirmation",
+            "description": "Whether do we need to confirm enabling/disabling of inputs or outputs",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "passwordHash",
+            "description": "[Argon2] hash of the password that this server's GraphQL API is\nprotected with, if any.\n\nNon-`null` value means that any request to GraphQL API should perform\n[HTTP Basic auth][1]. Any username is allowed, but the password should\nmatch this hash.\n\n[Argon2]: https://en.wikipedia.org/wiki/Argon2\n[1]: https://en.wikipedia.org/wiki/Basic_access_authentication",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "passwordOutputHash",
+            "description": "Password hash for single output application",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "googleApiKey",
+            "description": "Google API key for file downloading",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maxDownloadingFiles",
+            "description": "Max number of files allowed in [Restream]'s playlist\nThis value can be overwritten by the similar setting\non a particular [Restream]",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "UNumber",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ServerInfo",
+        "description": "Server's info",
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "cpuUsage",
+            "description": "Total CPU usage, %",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cpuCores",
+            "description": "CPU cores count",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ramTotal",
+            "description": "Total RAM installed on current machine",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ramFree",
+            "description": "Free (available) RAM",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "txDelta",
+            "description": "Network traffic, transferred last second",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rxDelta",
+            "description": "Network traffic, received last second",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "errorMsg",
+            "description": "Error message",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PlaylistFileInfo",
+        "description": "Information necessary for every video in playlist",
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "fileId",
+            "description": "Google ID of this file",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "FileId",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "Name of this file",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "wasPlayed",
+            "description": "Whether the file was already played",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "StreamStatistics",
+        "description": "Stream statistics",
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "audioCodecName",
+            "description": "Name of audio codec.  Example: \"aac\"",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audioChannelLayout",
+            "description": "Stereo / Mono layout",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audioSampleRate",
+            "description": "Audio sample rate. Example - \"44100\"",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "audioChannels",
+            "description": "Count of audio channels. Example: 2",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "UNumber",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "videoCodecName",
+            "description": "Name of video codec. Example: \"h264\"",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "videoRFrameRate",
+            "description": "Video frame rate (fps). Example: \"30/1\"",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "videoWidth",
+            "description": "Video width",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "UNumber",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "videoHeight",
+            "description": "Video height",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "UNumber",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bitRate",
+            "description": "Total bit rate",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "error",
+            "description": "Error message, if we could not retrieve stream info",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "MixinId",
+        "description": "ID of a `Mixin`.",
+        "specifiedByUrl": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RemoteInputSrc",
+        "description": "Remote upstream source to pull a live stream by an `Input` from.",
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "url",
+            "description": "URL of this `RemoteInputSrc`.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "InputSrcUrl",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "label",
+            "description": "Label for this Endpoint",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Label",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "UNumber",
+        "description": "Generic number for using with Graphql",
+        "specifiedByUrl": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Playlist",
+        "description": "Video playlist for each restream as an alternative to stream input",
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": "Unique ID of this playlist",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "PlaylistId",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "queue",
+            "description": "List of video files in this playlist",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "PlaylistFileInfo",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currentlyPlayingFile",
+            "description": "Currently playing file.\nSetting this value to `Some(...)` will override current restreamer input\nand this file will be streamed instead.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PlaylistFileInfo",
               "ofType": null
             },
             "isDeprecated": false,
@@ -232,109 +1298,121 @@
         "possibleTypes": null
       },
       {
-        "kind": "SCALAR",
-        "name": "OutputId",
-        "description": "ID of an `Output`.",
+        "kind": "OBJECT",
+        "name": "Restream",
+        "description": "Re-stream of a live stream from one `Input` to many `Output`s.",
         "specifiedByUrl": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "__DirectiveLocation",
-        "description": null,
-        "specifiedByUrl": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
+        "fields": [
           {
-            "name": "QUERY",
-            "description": null,
+            "name": "id",
+            "description": "Unique ID of this `Input`.\n\nOnce assigned, it never changes.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "RestreamId",
+                "ofType": null
+              }
+            },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "MUTATION",
-            "description": null,
+            "name": "key",
+            "description": "Unique key of this `Restream` identifying it, and used to form its\nendpoints URLs.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "RestreamKey",
+                "ofType": null
+              }
+            },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "SUBSCRIPTION",
-            "description": null,
+            "name": "label",
+            "description": "Optional label of this `Restream`.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Label",
+              "ofType": null
+            },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "FIELD",
-            "description": null,
+            "name": "playlist",
+            "description": "Playlist for this restream",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Playlist",
+                "ofType": null
+              }
+            },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "SCALAR",
-            "description": null,
+            "name": "input",
+            "description": "`Input` that a live stream is received from.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Input",
+                "ofType": null
+              }
+            },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "FRAGMENT_DEFINITION",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "FIELD_DEFINITION",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "VARIABLE_DEFINITION",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "FRAGMENT_SPREAD",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "INLINE_FRAGMENT",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ENUM_VALUE",
-            "description": null,
+            "name": "outputs",
+            "description": "`Output`s that a live stream is re-streamed to.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Output",
+                    "ofType": null
+                  }
+                }
+              }
+            },
             "isDeprecated": false,
             "deprecationReason": null
           }
         ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "SCALAR",
-        "name": "Delay",
-        "description": "Delay of a [`Mixin`] being mixed with an [`Output`].\n\n[`Mixin`]: crate::state::Mixin\n[`Output`]: crate::state::Output",
-        "specifiedByUrl": null,
-        "fields": null,
         "inputFields": null,
-        "interfaces": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
       {
         "kind": "SCALAR",
-        "name": "Label",
-        "description": "Label of a [`Restream`] or an [`Output`].\n\n[`Restream`]: crate::state::Restream\n[`Output`]: crate::state::Output",
+        "name": "OutputId",
+        "description": "ID of an `Output`.",
         "specifiedByUrl": null,
         "fields": null,
         "inputFields": null,
@@ -1788,580 +2866,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "Input",
-        "description": "Upstream source that a `Restream` receives a live stream from.",
-        "specifiedByUrl": null,
-        "fields": [
-          {
-            "name": "id",
-            "description": "Unique ID of this `Input`.\n\nOnce assigned, it never changes.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "InputId",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "key",
-            "description": "Key of this `Input` to expose its `InputEndpoint`s with for accepting\nand serving a live stream.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "InputKey",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "endpoints",
-            "description": "Endpoints of this `Input` serving a live stream for `Output`s and\nclients.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "InputEndpoint",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "src",
-            "description": "Source to pull a live stream from.\n\nIf specified, then this `Input` will pull a live stream from it (pull\nkind), otherwise this `Input` will await a live stream to be pushed\n(push kind).",
-            "args": [],
-            "type": {
-              "kind": "UNION",
-              "name": "InputSrc",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enabled",
-            "description": "Indicator whether this `Input` is enabled, so is allowed to receive a\nlive stream from its upstream sources.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "SCALAR",
-        "name": "InputSrcUrl",
-        "description": "[`Url`] of a [`RemoteInputSrc`].\n\nOnly the following URLs are allowed at the moment:\n- [RTMP] URL (starting with `rtmp://` or `rtmps://` scheme and having a\n  host);\n- [HLS] URL (starting with `http://` or `https://` scheme, having a host,\n  and with `.m3u8` extension in its path).\n\n[HLS]: https://en.wikipedia.org/wiki/HTTP_Live_Streaming\n[RTMP]: https://en.wikipedia.org/wiki/Real-Time_Messaging_Protocol",
-        "specifiedByUrl": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "SCALAR",
-        "name": "Float",
-        "description": null,
-        "specifiedByUrl": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "Direction",
-        "description": "Direction",
-        "specifiedByUrl": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "UP",
-            "description": "Up",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "DOWN",
-            "description": "Down",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "Status",
-        "description": "Status indicating availability of an `Input`, `Output`, or a `Mixin`.",
-        "specifiedByUrl": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "OFFLINE",
-            "description": "Inactive, no operations are performed and no media traffic is flowed.",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "INITIALIZING",
-            "description": "Initializing, media traffic doesn't yet flow as expected.",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ONLINE",
-            "description": "Active, all operations are performing successfully and media traffic\nflows as expected.",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "UNSTABLE",
-            "description": "Failed recently",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "PasswordKind",
-        "description": "Specifies kind of password",
-        "specifiedByUrl": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "MAIN",
-            "description": "Password for main application",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "OUTPUT",
-            "description": "Password for single output application",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "__Schema",
-        "description": null,
-        "specifiedByUrl": null,
-        "fields": [
-          {
-            "name": "description",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "types",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "__Type",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "queryType",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "__Type",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "mutationType",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "__Type",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "subscriptionType",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "__Type",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "directives",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "__Directive",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "SCALAR",
-        "name": "Int",
-        "description": null,
-        "specifiedByUrl": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "Query",
-        "description": null,
-        "specifiedByUrl": null,
-        "fields": [
-          {
-            "name": "info",
-            "description": "Returns the current `Info` parameters of this server.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Info",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "serverInfo",
-            "description": "Returns the current `ServerInfo`",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ServerInfo",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "allRestreams",
-            "description": "Returns all the `Restream`s happening on this server.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Restream",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dvrFiles",
-            "description": "Returns list of recorded files of the specified `Output`.\n\nIf returned list is empty, the there is no recorded files for the\nspecified `Output`.\n\nEach recorded file is represented as a relative path on [SRS] HTTP\nserver in `dvr/` directory, so the download link should look like this:\n```ignore\nhttp://my.host:8080/dvr/returned/file/path.flv\nhttp://my.host:8080/dvr/returned/file/path.wav\nhttp://my.host:8080/dvr/returned/file/path.mp3\n```\n\n[SRS]: https://github.com/ossrs/srs",
-            "args": [
-              {
-                "name": "id",
-                "description": "ID of the `Output` to return recorded files of.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "OutputId",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "export",
-            "description": "Returns `Restream`s happening on this server and identifiable by the\ngiven `ids` in an exportable JSON format.\n\nIf no `ids` specified, then returns all the `Restream`s happening on\nthis server at the moment.",
-            "args": [
-              {
-                "name": "ids",
-                "description": "IDs of `Restream`s to be exported. \n\n If empty, then all the `Restream`s will be exported.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "SCALAR",
-                        "name": "RestreamId",
-                        "ofType": null
-                      }
-                    }
-                  }
-                },
-                "defaultValue": "[]"
-              }
-            ],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "InputEndpoint",
-        "description": "Endpoint of an `Input` serving a live stream for `Output`s and clients.",
-        "specifiedByUrl": null,
-        "fields": [
-          {
-            "name": "id",
-            "description": "Unique ID of this `InputEndpoint`.\n\nOnce assigned, it never changes.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "EndpointId",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "kind",
-            "description": "Kind of this `InputEndpoint`.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "InputEndpointKind",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "label",
-            "description": "User defined label for each Endpoint",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Label",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "fileId",
-            "description": "If the endpoint is of type FILE, then this contains\nthe file ID that is in the [`State::files`]\n\n[`State::files`]: crate::state::State::files",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "FileId",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "status",
-            "description": "`Status` of this `InputEndpoint` indicating whether it actually serves a\nlive stream ready to be consumed by `Output`s and clients.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "Status",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "streamStat",
-            "description": "Corresponding stream info",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "StreamStatistics",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "SCALAR",
-        "name": "Url",
-        "description": null,
-        "specifiedByUrl": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "__Type",
         "description": null,
         "specifiedByUrl": null,
@@ -2559,13 +3063,239 @@
         "possibleTypes": null
       },
       {
-        "kind": "SCALAR",
-        "name": "PlaylistId",
-        "description": "ID of a `Playlist`.",
+        "kind": "ENUM",
+        "name": "Direction",
+        "description": "Direction",
         "specifiedByUrl": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
+        "enumValues": [
+          {
+            "name": "UP",
+            "description": "Up",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DOWN",
+            "description": "Down",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "Status",
+        "description": "Status indicating availability of an `Input`, `Output`, or a `Mixin`.",
+        "specifiedByUrl": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "OFFLINE",
+            "description": "Inactive, no operations are performed and no media traffic is flowed.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INITIALIZING",
+            "description": "Initializing, media traffic doesn't yet flow as expected.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ONLINE",
+            "description": "Active, all operations are performing successfully and media traffic\nflows as expected.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UNSTABLE",
+            "description": "Failed recently",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "PasswordKind",
+        "description": "Specifies kind of password",
+        "specifiedByUrl": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "MAIN",
+            "description": "Password for main application",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OUTPUT",
+            "description": "Password for single output application",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Int",
+        "description": null,
+        "specifiedByUrl": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Query",
+        "description": null,
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "info",
+            "description": "Returns the current `Info` parameters of this server.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Info",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "serverInfo",
+            "description": "Returns the current `ServerInfo`",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ServerInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "allRestreams",
+            "description": "Returns all the `Restream`s happening on this server.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Restream",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dvrFiles",
+            "description": "Returns list of recorded files of the specified `Output`.\n\nIf returned list is empty, the there is no recorded files for the\nspecified `Output`.\n\nEach recorded file is represented as a relative path on [SRS] HTTP\nserver in `dvr/` directory, so the download link should look like this:\n```ignore\nhttp://my.host:8080/dvr/returned/file/path.flv\nhttp://my.host:8080/dvr/returned/file/path.wav\nhttp://my.host:8080/dvr/returned/file/path.mp3\n```\n\n[SRS]: https://github.com/ossrs/srs",
+            "args": [
+              {
+                "name": "id",
+                "description": "ID of the `Output` to return recorded files of.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "OutputId",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "export",
+            "description": "Returns `Restream`s happening on this server and identifiable by the\ngiven `ids` in an exportable JSON format.\n\nIf no `ids` specified, then returns all the `Restream`s happening on\nthis server at the moment.",
+            "args": [
+              {
+                "name": "ids",
+                "description": "IDs of `Restream`s to be exported. \n\n If empty, then all the `Restream`s will be exported.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "RestreamId",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": "[]"
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -2910,84 +3640,21 @@
         "possibleTypes": null
       },
       {
-        "kind": "SCALAR",
-        "name": "String",
-        "description": null,
-        "specifiedByUrl": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "OBJECT",
-        "name": "__Field",
-        "description": null,
+        "name": "RestreamWithParent",
+        "description": "Restream with its source output if it has any",
         "specifiedByUrl": null,
         "fields": [
           {
-            "name": "name",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "args",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "__InputValue",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "type",
-            "description": null,
+            "name": "restream",
+            "description": "Restream info",
             "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "__Type",
+                "name": "Restream",
                 "ofType": null
               }
             },
@@ -2995,28 +3662,12 @@
             "deprecationReason": null
           },
           {
-            "name": "isDeprecated",
-            "description": null,
+            "name": "parent",
+            "description": "Restream parent if it has any",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deprecationReason",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
+              "kind": "OBJECT",
+              "name": "RestreamParent",
               "ofType": null
             },
             "isDeprecated": false,
@@ -3062,128 +3713,69 @@
         ]
       },
       {
-        "kind": "OBJECT",
-        "name": "Mixin",
-        "description": "Additional source for an `Output` to be mixed with before re-streaming to\nthe destination.",
+        "kind": "ENUM",
+        "name": "__TypeKind",
+        "description": "GraphQL type kind\n\nThe GraphQL specification defines a number of type kinds - the meta type of a type.",
         "specifiedByUrl": null,
-        "fields": [
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
           {
-            "name": "id",
-            "description": "Unique ID of this `Mixin`.\n\nOnce assigned, it never changes.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "MixinId",
-                "ofType": null
-              }
-            },
+            "name": "SCALAR",
+            "description": "## Scalar types\n\nScalar types appear as the leaf nodes of GraphQL queries. Strings, numbers, and booleans are the built in types, and while it's possible to define your own, it's relatively uncommon.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "src",
-            "description": "URL of the source to be mixed with an `Output`.\n\nAt the moment, only [TeamSpeak] is supported.\n\n[TeamSpeak]: https://teamspeak.com",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "MixinSrcUrl",
-                "ofType": null
-              }
-            },
+            "name": "OBJECT",
+            "description": "## Object types\n\nThe most common type to be implemented by users. Objects have fields and can implement interfaces.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "volume",
-            "description": "Volume rate of this `Mixin`'s audio tracks to mix them with.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Volume",
-                "ofType": null
-              }
-            },
+            "name": "INTERFACE",
+            "description": "## Interface types\n\nInterface types are used to represent overlapping fields between multiple types, and can be queried for their concrete type.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "delay",
-            "description": "Delay that this `Mixin` should wait before being mixed with an `Output`.\n\nVery useful to fix de-synchronization issues and correct timings between\na `Mixin` and its `Output`.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Delay",
-                "ofType": null
-              }
-            },
+            "name": "UNION",
+            "description": "## Union types\n\nUnions are similar to interfaces but can not contain any fields on their own.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "status",
-            "description": "`Status` of this `Mixin` indicating whether it provides an actual media\nstream to be mixed with its `Output`.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "Status",
-                "ofType": null
-              }
-            },
+            "name": "ENUM",
+            "description": "## Enum types\n\nLike scalars, enum types appear as the leaf nodes of GraphQL queries.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "sidechain",
-            "description": "Side-chain audio of `Output` with this `Mixin`.\n\nHelps to automatically control audio level of `Mixin`\nbased on level of `Output`.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
+            "name": "INPUT_OBJECT",
+            "description": "## Input objects\n\nRepresents complex values provided in queries _into_ the system.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "LIST",
+            "description": "## List types\n\nRepresent lists of other types. This library provides implementations for vectors and slices, but other Rust types can be extended to serve as GraphQL lists.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NON_NULL",
+            "description": "## Non-null types\n\nIn GraphQL, nullable types are the default. By putting a `!` after a type, it becomes non-nullable.",
             "isDeprecated": false,
             "deprecationReason": null
           }
         ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
         "possibleTypes": null
       },
       {
         "kind": "SCALAR",
         "name": "MixinSrcUrl",
         "description": "[`Url`] of a [`Mixin::src`].\n\nOnly the following URLs are allowed at the moment:\n- [TeamSpeak] URL (starting with `ts://` scheme and having a host);\n- [MP3] HTTP URL (starting with `http://` or `https://` scheme, having a\n  host and `.mp3` extension in its path).\n\n[MP3]: https://en.wikipedia.org/wiki/MP3\n[TeamSpeak]: https://teamspeak.com",
-        "specifiedByUrl": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "SCALAR",
-        "name": "InputId",
-        "description": "ID of an `Input`.",
         "specifiedByUrl": null,
         "fields": null,
         "inputFields": null,
@@ -3214,214 +3806,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "Info",
-        "description": "Information about parameters that this server operates with.",
-        "specifiedByUrl": null,
-        "fields": [
-          {
-            "name": "publicHost",
-            "description": "Host that this server is reachable via in public.\n\nUse it for constructing URLs to this server.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "title",
-            "description": "Title of the server",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deleteConfirmation",
-            "description": "Whether do we need to confirm deletion of inputs and outputs",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enableConfirmation",
-            "description": "Whether do we need to confirm enabling/disabling of inputs or outputs",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "passwordHash",
-            "description": "[Argon2] hash of the password that this server's GraphQL API is\nprotected with, if any.\n\nNon-`null` value means that any request to GraphQL API should perform\n[HTTP Basic auth][1]. Any username is allowed, but the password should\nmatch this hash.\n\n[Argon2]: https://en.wikipedia.org/wiki/Argon2\n[1]: https://en.wikipedia.org/wiki/Basic_access_authentication",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "passwordOutputHash",
-            "description": "Password hash for single output application",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "googleApiKey",
-            "description": "Google API key for file downloading",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "maxDownloadingFiles",
-            "description": "Max number of files allowed in [Restream]'s playlist\nThis value can be overwritten by the similar setting\non a particular [Restream]",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "UNumber",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "ServerInfo",
-        "description": "Server's info",
-        "specifiedByUrl": null,
-        "fields": [
-          {
-            "name": "cpuUsage",
-            "description": "Total CPU usage, %",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cpuCores",
-            "description": "CPU cores count",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ramTotal",
-            "description": "Total RAM installed on current machine",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ramFree",
-            "description": "Free (available) RAM",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "txDelta",
-            "description": "Network traffic, transferred last second",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "rxDelta",
-            "description": "Network traffic, received last second",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "errorMsg",
-            "description": "Error message",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "SCALAR",
         "name": "RestreamKey",
         "description": "Key of a [`Restream`] identifying it, and used to form its endpoints URLs.",
@@ -3429,198 +3813,6 @@
         "fields": null,
         "inputFields": null,
         "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "PlaylistFileInfo",
-        "description": "Information necessary for every video in playlist",
-        "specifiedByUrl": null,
-        "fields": [
-          {
-            "name": "fileId",
-            "description": "Google ID of this file",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "FileId",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": "Name of this file",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "wasPlayed",
-            "description": "Whether the file was already played",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "StreamStatistics",
-        "description": "Stream statistics",
-        "specifiedByUrl": null,
-        "fields": [
-          {
-            "name": "audioCodecName",
-            "description": "Name of audio codec.  Example: \"aac\"",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "audioChannelLayout",
-            "description": "Stereo / Mono layout",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "audioSampleRate",
-            "description": "Audio sample rate. Example - \"44100\"",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "audioChannels",
-            "description": "Count of audio channels. Example: 2",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "UNumber",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "videoCodecName",
-            "description": "Name of video codec. Example: \"h264\"",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "videoRFrameRate",
-            "description": "Video frame rate (fps). Example: \"30/1\"",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "videoWidth",
-            "description": "Video width",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "UNumber",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "videoHeight",
-            "description": "Video height",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "UNumber",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "bitRate",
-            "description": "Total bit rate",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "error",
-            "description": "Error message, if we could not retrieve stream info",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -3675,104 +3867,6 @@
         "specifiedByUrl": null,
         "fields": null,
         "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "SCALAR",
-        "name": "MixinId",
-        "description": "ID of a `Mixin`.",
-        "specifiedByUrl": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "SCALAR",
-        "name": "RestreamId",
-        "description": "ID of a `Restream`.",
-        "specifiedByUrl": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "RemoteInputSrc",
-        "description": "Remote upstream source to pull a live stream by an `Input` from.",
-        "specifiedByUrl": null,
-        "fields": [
-          {
-            "name": "url",
-            "description": "URL of this `RemoteInputSrc`.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "InputSrcUrl",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "label",
-            "description": "Label for this Endpoint",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Label",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "BackupInput",
-        "description": "Backup input",
-        "specifiedByUrl": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "key",
-            "description": "Key for this [`BackupInput`]",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "InputKey",
-                "ofType": null
-              }
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "src",
-            "description": "URL to pull a live stream from for a backup endpoint.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "InputSrcUrl",
-              "ofType": null
-            },
-            "defaultValue": null
-          }
-        ],
         "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
@@ -3918,8 +4012,8 @@
             "deprecationReason": null
           },
           {
-            "name": "restream",
-            "description": "Subscribes to updates of specific restream",
+            "name": "restreamWithParent",
+            "description": null,
             "args": [
               {
                 "name": "id",
@@ -3938,7 +4032,7 @@
             ],
             "type": {
               "kind": "OBJECT",
-              "name": "Restream",
+              "name": "RestreamWithParent",
               "ofType": null
             },
             "isDeprecated": false,
@@ -3951,13 +4045,70 @@
         "possibleTypes": null
       },
       {
-        "kind": "SCALAR",
-        "name": "UNumber",
-        "description": "Generic number for using with Graphql",
+        "kind": "OBJECT",
+        "name": "__EnumValue",
+        "description": null,
         "specifiedByUrl": null,
-        "fields": null,
+        "fields": [
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isDeprecated",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deprecationReason",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "inputFields": null,
-        "interfaces": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -4054,178 +4205,49 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "Playlist",
-        "description": "Video playlist for each restream as an alternative to stream input",
+        "kind": "SCALAR",
+        "name": "RestreamId",
+        "description": "ID of a `Restream`.",
         "specifiedByUrl": null,
-        "fields": [
-          {
-            "name": "id",
-            "description": "Unique ID of this playlist",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "PlaylistId",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "queue",
-            "description": "List of video files in this playlist",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "PlaylistFileInfo",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "currentlyPlayingFile",
-            "description": "Currently playing file.\nSetting this value to `Some(...)` will override current restreamer input\nand this file will be streamed instead.",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "PlaylistFileInfo",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
+        "fields": null,
         "inputFields": null,
-        "interfaces": [],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "Restream",
-        "description": "Re-stream of a live stream from one `Input` to many `Output`s.",
+        "kind": "INPUT_OBJECT",
+        "name": "BackupInput",
+        "description": "Backup input",
         "specifiedByUrl": null,
-        "fields": [
-          {
-            "name": "id",
-            "description": "Unique ID of this `Input`.\n\nOnce assigned, it never changes.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "RestreamId",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
+        "fields": null,
+        "inputFields": [
           {
             "name": "key",
-            "description": "Unique key of this `Restream` identifying it, and used to form its\nendpoints URLs.",
-            "args": [],
+            "description": "Key for this [`BackupInput`]",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "RestreamKey",
+                "name": "InputKey",
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "defaultValue": null
           },
           {
-            "name": "label",
-            "description": "Optional label of this `Restream`.",
-            "args": [],
+            "name": "src",
+            "description": "URL to pull a live stream from for a backup endpoint.",
             "type": {
               "kind": "SCALAR",
-              "name": "Label",
+              "name": "InputSrcUrl",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "playlist",
-            "description": "Playlist for this restream",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Playlist",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "input",
-            "description": "`Input` that a live stream is received from.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Input",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "outputs",
-            "description": "`Output`s that a live stream is re-streamed to.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Output",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "defaultValue": null
           }
         ],
-        "inputFields": null,
-        "interfaces": [],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -4273,62 +4295,124 @@
       },
       {
         "kind": "ENUM",
-        "name": "__TypeKind",
-        "description": "GraphQL type kind\n\nThe GraphQL specification defines a number of type kinds - the meta type of a type.",
+        "name": "__DirectiveLocation",
+        "description": null,
         "specifiedByUrl": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
           {
+            "name": "QUERY",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MUTATION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUBSCRIPTION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FIELD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "SCALAR",
-            "description": "## Scalar types\n\nScalar types appear as the leaf nodes of GraphQL queries. Strings, numbers, and booleans are the built in types, and while it's possible to define your own, it's relatively uncommon.",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "OBJECT",
-            "description": "## Object types\n\nThe most common type to be implemented by users. Objects have fields and can implement interfaces.",
+            "name": "FRAGMENT_DEFINITION",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "INTERFACE",
-            "description": "## Interface types\n\nInterface types are used to represent overlapping fields between multiple types, and can be queried for their concrete type.",
+            "name": "FIELD_DEFINITION",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "UNION",
-            "description": "## Union types\n\nUnions are similar to interfaces but can not contain any fields on their own.",
+            "name": "VARIABLE_DEFINITION",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "ENUM",
-            "description": "## Enum types\n\nLike scalars, enum types appear as the leaf nodes of GraphQL queries.",
+            "name": "FRAGMENT_SPREAD",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "INPUT_OBJECT",
-            "description": "## Input objects\n\nRepresents complex values provided in queries _into_ the system.",
+            "name": "INLINE_FRAGMENT",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "LIST",
-            "description": "## List types\n\nRepresent lists of other types. This library provides implementations for vectors and slices, but other Rust types can be extended to serve as GraphQL lists.",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "NON_NULL",
-            "description": "## Non-null types\n\nIn GraphQL, nullable types are the default. By putting a `!` after a type, it becomes non-nullable.",
+            "name": "ENUM_VALUE",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RestreamParent",
+        "description": "Restream parent which contains output that streams to the current restream",
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "restream",
+            "description": "parent restream",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Restream",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "outputId",
+            "description": "output ID of the parent restream output that streams to the child",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "OutputId",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       }
     ],

--- a/components/restreamer/client/api/client.graphql
+++ b/components/restreamer/client/api/client.graphql
@@ -36,10 +36,19 @@ subscription State {
     }
 }
 
-subscription SingleRestream($id: RestreamId!) {
-    restream(id: $id) {
-        ...restreamBasic
-        ...restreamPlaylist
+subscription RestreamWithParent($id: RestreamId!) {
+    restreamWithParent(id: $id) {
+        restream {
+            ...restreamBasic
+            ...restreamPlaylist
+        }
+        parent {
+            restream {
+                id
+                ...restreamOutputs
+            }
+            outputId
+        }
     }
 }
 

--- a/components/restreamer/client/cypress/support/commands.js
+++ b/components/restreamer/client/cypress/support/commands.js
@@ -174,7 +174,10 @@ Cypress.Commands.add('importJsonConf', (host) => {
           "label": "File Record",
           "enabled": true
         }
-      ]
+      ],
+      "playlist": {
+        "queue": []
+      }
     },
     {
       "id": "7cea855f-c250-4378-9d49-ccc93d22d3d1",
@@ -192,6 +195,9 @@ Cypress.Commands.add('importJsonConf', (host) => {
           "remote_url": "rtmp://${host}/en/primary"
         },
         "enabled": true
+      },
+      "playlist": {
+        "queue": []
       }
     },
     {
@@ -238,7 +244,10 @@ Cypress.Commands.add('importJsonConf', (host) => {
           "preview_url": "https://creativesociety.com/ru",
           "enabled": true
         }
-      ]
+      ],
+      "playlist": {
+        "queue": []
+      }
     },
     {
       "id": "399aefb2-e61e-46cf-a2fb-648bf252f4e6",
@@ -253,6 +262,9 @@ Cypress.Commands.add('importJsonConf', (host) => {
           }
         ],
         "enabled": true
+      },
+      "playlist": {
+        "queue": []
       }
     }
   ]

--- a/components/restreamer/client/src/components/AppFullStream.svelte
+++ b/components/restreamer/client/src/components/AppFullStream.svelte
@@ -11,7 +11,7 @@
     RestreamWithParent,
     TuneDelay,
     TuneVolume,
-    TuneSidechain
+    TuneSidechain,
   } from '../../api/client.graphql';
   import { setClient, subscribe } from 'svelte-apollo';
   import Shell from './common/Shell.svelte';
@@ -54,25 +54,31 @@
 
   $: infoError = $info?.error;
   $: isLoading = !isOnline || $restreamWithParent.loading;
-  $: canRenderMainComponent = isOnline && $restreamWithParent?.data && $info?.data && $filesInfo?.data;
+  $: canRenderMainComponent =
+    isOnline && $restreamWithParent?.data && $info?.data && $filesInfo?.data;
 
   $: restreamError = $restreamWithParent?.error;
   $: sInfo = $serverInfo?.data?.serverInfo;
   $: filesError = $filesInfo?.error;
   $: files = (canRenderMainComponent && $filesInfo?.data?.files) || [];
 
-  $: restream = canRenderMainComponent && $restreamWithParent.data?.restreamWithParent?.restream;
-  $: parentData = canRenderMainComponent && $restreamWithParent.data?.restreamWithParent?.parent;
-  $: parentRestreamOutput = canRenderMainComponent && parentData?.restream?.outputs?.find(
-      (o) => o.id === parentData.outputId
-    );
+  $: restream =
+    canRenderMainComponent &&
+    $restreamWithParent.data?.restreamWithParent?.restream;
+  $: parentData =
+    canRenderMainComponent &&
+    $restreamWithParent.data?.restreamWithParent?.parent;
+  $: parentRestreamOutput =
+    canRenderMainComponent &&
+    parentData?.restream?.outputs?.find((o) => o.id === parentData.outputId);
 
-  $: translationYoutubeUrl = canRenderMainComponent && restream?.outputs
+  $: translationYoutubeUrl =
+    canRenderMainComponent &&
+    restream?.outputs
       .filter((x) => isYoutubeVideo(x.previewUrl))
       .map((x) => x.previewUrl)[0];
 
   $: playlist = restream?.playlist;
-
 </script>
 
 <template>

--- a/components/restreamer/client/src/components/AppFullStream.svelte
+++ b/components/restreamer/client/src/components/AppFullStream.svelte
@@ -8,9 +8,10 @@
     Info,
     RemoveOutput,
     ServerInfo,
-    SingleRestream,
+    RestreamWithParent,
     TuneDelay,
     TuneVolume,
+    TuneSidechain
   } from '../../api/client.graphql';
   import { setClient, subscribe } from 'svelte-apollo';
   import Shell from './common/Shell.svelte';
@@ -18,6 +19,7 @@
   import OutputModal from '../modals/OutputModal.svelte';
   import YoutubePlayer from './common/YoutubePlayer.svelte';
   import Restream from './Restream.svelte';
+  import Output from './Output.svelte';
 
   let outputMutations = {
     DisableOutput,
@@ -25,6 +27,7 @@
     RemoveOutput,
     TuneVolume,
     TuneDelay,
+    TuneSidechain,
   };
 
   const gqlClient = createGraphQlClient(
@@ -38,7 +41,7 @@
   const restreamId = urlParams.get('restream-id');
 
   let isOnline = false;
-  const singleRestream = subscribe(SingleRestream, {
+  const restreamWithParent = subscribe(RestreamWithParent, {
     variables: { id: restreamId.toString() },
     errorPolicy: 'all',
   });
@@ -50,29 +53,33 @@
   $: document.title = (isOnline ? '' : '🔴  ') + title;
 
   $: infoError = $info?.error;
-  $: isLoading = !isOnline || $singleRestream.loading;
-  $: canRenderMainComponent =
-    isOnline && $singleRestream.data && $info.data && $filesInfo?.data;
-  $: restreamError = $singleRestream?.error;
+  $: isLoading = !isOnline || $restreamWithParent.loading;
+  $: canRenderMainComponent = isOnline && $restreamWithParent?.data && $info?.data && $filesInfo?.data;
+
+  $: restreamError = $restreamWithParent?.error;
   $: sInfo = $serverInfo?.data?.serverInfo;
-  $: restream = canRenderMainComponent && $singleRestream?.data?.restream;
   $: filesError = $filesInfo?.error;
   $: files = (canRenderMainComponent && $filesInfo?.data?.files) || [];
 
-  $: translationYoutubeUrl =
-    canRenderMainComponent &&
-    restream.outputs
+  $: restream = canRenderMainComponent && $restreamWithParent.data?.restreamWithParent?.restream;
+  $: parentData = canRenderMainComponent && $restreamWithParent.data?.restreamWithParent?.parent;
+  $: parentRestreamOutput = canRenderMainComponent && parentData?.restream?.outputs?.find(
+      (o) => o.id === parentData.outputId
+    );
+
+  $: translationYoutubeUrl = canRenderMainComponent && restream?.outputs
       .filter((x) => isYoutubeVideo(x.previewUrl))
       .map((x) => x.previewUrl)[0];
 
   $: playlist = restream?.playlist;
+
 </script>
 
 <template>
   <Shell
     {isLoading}
     {canRenderMainComponent}
-    error={restreamError || infoError | filesError}
+    error={restreamError || infoError || filesError}
     serverInfo={sInfo}
   >
     <div slot="main">
@@ -84,6 +91,17 @@
         isFullView="true"
         globalOutputsFilters={[]}
       />
+      {#if parentRestreamOutput && parentRestreamOutput.mixins?.length > 0}
+        <div class="section-title">Sound mixer</div>
+        <section class="uk-section uk-section-muted single-output">
+          <Output
+            restream_id={parentData.restream?.id}
+            value={parentRestreamOutput}
+            isReadOnly="true"
+            mutations={outputMutations}
+          />
+        </section>
+      {/if}
       <div class="section-title">Playlist</div>
       <section class="uk-section uk-section-muted uk-padding-remove">
         <Playlist restreamId={restream.id} {playlist} {files} />
@@ -104,6 +122,11 @@
     margin-bottom: 4px
     font-size: 1.2rem
     text-transform: uppercase
+
+  .single-output
+    padding: 16px
+    :global(.volume input)
+      width: 90% !important
 
   .video-player
     padding: 16px

--- a/components/restreamer/client/src/components/Playlist.svelte
+++ b/components/restreamer/client/src/components/Playlist.svelte
@@ -63,6 +63,9 @@
 
   $: hasDownloadingFiles = Boolean(queue.find((x) => x.isDownloading));
 
+  $: hasFilesInPlaylist = Boolean(queue?.length > 0);
+
+
   let googleDriveFolderId = '';
   let isValidFolderIdInput = true;
 
@@ -173,43 +176,15 @@
     e.preventDefault();
     dragDisabled = false;
   }
+
 </script>
 
 <template>
   <div class="playlist">
     <div class="uk-flex uk-flex-middle uk-margin-bottom playlist-toolbar">
       <PlaylistStatus files={queue} />
-      <Confirm let:confirm>
-        <button
-          class="uk-button uk-button-default uk-button-small uk-margin-auto-left"
-          data-testid="start-all-outputs"
-          title="Start all incomplete downloads of files in the playlist"
-          on:click={() => confirm(startPlaylistDownload)}
-          ><span>Start downloads</span>
-        </button>
-        <span slot="title">Start downloads</span>
-        <span slot="description"
-          >This will restart all not complete downloads of files in playlist.
-        </span>
-        <span slot="confirm">Start downloads</span>
-      </Confirm>
-
-      <Confirm let:confirm>
-        <button
-          class="uk-button uk-button-default uk-button-small"
-          data-testid="stop-all-outputs"
-          title="Stop all downloads of all files in the playlist"
-          on:click={() => confirm(stopPlaylistDownload)}
-          value=""><span>Stop downloads</span></button
-        >
-        <span slot="title">Stop all active downloads</span>
-        <span slot="description"
-          >This will stop active downloads of files in playlist.
-        </span>
-        <span slot="confirm">Stop downloads</span>
-      </Confirm>
     </div>
-    <div class="google-drive-dir uk-flex">
+    <div class="google-drive-dir uk-flex uk-flex-middle">
       <label for="gdrive">Add files from Google Drive</label>
       <input
         id="gdrive"
@@ -223,13 +198,49 @@
 
       <button
         disabled={!googleDriveFolderId.trim()}
-        class="uk-button uk-button-primary uk-button-small uk-flex-none"
+        class="uk-button uk-button-primary uk-button-small uk-flex-none load-file"
         on:click={() => loadPlaylist(googleDriveFolderId)}
       >
         <i class="uk-icon" uk-icon="cloud-download" />&nbsp;<span
           >Load files</span
         >
       </button>
+      <Confirm let:confirm>
+        <button
+          class="uk-button uk-button-link url-action-btn uk-margin-small-left start-download"
+          class:uk-hidden={hasFilesInPlaylist && hasDownloadingFiles}
+          data-testid="start-all-outputs"
+          title="Start all incomplete downloads of files in the playlist"
+          on:click={() => confirm(startPlaylistDownload)}
+        >Start all downloads
+          <i
+            class="uk-icon"
+            uk-icon="icon: cloud-download; ratio: 0.8"
+          />&nbsp;
+        </button>
+        <span slot="title">Start all downloads</span>
+        <span slot="description"
+        >This will restart all not complete downloads of files in playlist.
+        </span>
+        <span slot="confirm">Start downloads</span>
+      </Confirm>
+
+      <Confirm let:confirm>
+        <button
+          class="uk-button uk-button-link url-action-btn uk-margin-small-left stop-download"
+          class:uk-hidden={hasFilesInPlaylist && !hasDownloadingFiles}
+          data-testid="stop-all-outputs"
+          title="Stop all downloads of all files in the playlist"
+          on:click={() => confirm(stopPlaylistDownload)}
+          value="">Cancel all downloads <i class="uk-icon" uk-icon="icon: ban; ratio: 0.8" />&nbsp;
+        </button
+        >
+        <span slot="title">Cancel all active downloads</span>
+        <span slot="description"
+        >This will stop active downloads of files in playlist.
+        </span>
+        <span slot="confirm">Stop downloads</span>
+      </Confirm>
     </div>
     <div
       class="playlist-items"
@@ -334,6 +345,13 @@
 
   .playlist
     padding: 16px
+
+    &:hover
+      .start-download, .stop-download, .load-file
+        opacity: 1
+
+  .start-download, .stop-download, .load-file
+      opacity: 0
 
   .playlist-toolbar
     gap: 4px

--- a/components/restreamer/client/src/components/Playlist.svelte
+++ b/components/restreamer/client/src/components/Playlist.svelte
@@ -184,7 +184,6 @@
     e.preventDefault();
     dragDisabled = false;
   }
-
 </script>
 
 <template>
@@ -220,15 +219,12 @@
           data-testid="start-all-outputs"
           title="Start all incomplete downloads of files in the playlist"
           on:click={() => confirm(startPlaylistDownload)}
-        >Start all downloads
-          <i
-            class="uk-icon"
-            uk-icon="icon: cloud-download; ratio: 0.8"
-          />&nbsp;
+          >Start all downloads
+          <i class="uk-icon" uk-icon="icon: cloud-download; ratio: 0.8" />&nbsp;
         </button>
         <span slot="title">Start all downloads</span>
         <span slot="description"
-        >This will restart all not complete downloads of files in playlist.
+          >This will restart all not complete downloads of files in playlist.
         </span>
         <span slot="confirm">Start downloads</span>
       </Confirm>
@@ -240,12 +236,15 @@
           data-testid="stop-all-outputs"
           title="Stop all downloads of all files in the playlist"
           on:click={() => confirm(stopPlaylistDownload)}
-          value="">Cancel all downloads <i class="uk-icon" uk-icon="icon: ban; ratio: 0.8" />&nbsp;
-        </button
-        >
+          value=""
+          >Cancel all downloads <i
+            class="uk-icon"
+            uk-icon="icon: ban; ratio: 0.8"
+          />&nbsp;
+        </button>
         <span slot="title">Cancel all active downloads</span>
         <span slot="description"
-        >This will stop active downloads of files in playlist.
+          >This will stop active downloads of files in playlist.
         </span>
         <span slot="confirm">Stop downloads</span>
       </Confirm>
@@ -257,9 +256,9 @@
           data-testid="clear-playlist"
           title="Clear playlist"
           on:click={() => confirm(clearPlaylist)}
-          value="">Clear playlist
-        </button
-        >
+          value=""
+          >Clear playlist
+        </button>
         <span slot="title">Clear all files in playlist</span>
         <span slot="description">All files will be removed from playlist.</span>
         <span slot="confirm">Clear playlist</span>

--- a/components/restreamer/client/src/components/Playlist.svelte
+++ b/components/restreamer/client/src/components/Playlist.svelte
@@ -65,7 +65,6 @@
 
   $: hasFilesInPlaylist = Boolean(queue?.length > 0);
 
-
   let googleDriveFolderId = '';
   let isValidFolderIdInput = true;
 
@@ -96,6 +95,15 @@
     try {
       const variables = { id: restreamId };
       await restartPlaylistDownload({ variables });
+    } catch (e) {
+      showError(e.message);
+    }
+  }
+
+  async function clearPlaylist() {
+    const variables = { restreamId, fileIds: [] };
+    try {
+      await setPlaylist({ variables });
     } catch (e) {
       showError(e.message);
     }
@@ -208,7 +216,7 @@
       <Confirm let:confirm>
         <button
           class="uk-button uk-button-link url-action-btn uk-margin-small-left start-download"
-          class:uk-hidden={hasFilesInPlaylist && hasDownloadingFiles}
+          class:uk-hidden={!hasFilesInPlaylist || hasDownloadingFiles}
           data-testid="start-all-outputs"
           title="Start all incomplete downloads of files in the playlist"
           on:click={() => confirm(startPlaylistDownload)}
@@ -228,7 +236,7 @@
       <Confirm let:confirm>
         <button
           class="uk-button uk-button-link url-action-btn uk-margin-small-left stop-download"
-          class:uk-hidden={hasFilesInPlaylist && !hasDownloadingFiles}
+          class:uk-hidden={!hasFilesInPlaylist || !hasDownloadingFiles}
           data-testid="stop-all-outputs"
           title="Stop all downloads of all files in the playlist"
           on:click={() => confirm(stopPlaylistDownload)}
@@ -240,6 +248,21 @@
         >This will stop active downloads of files in playlist.
         </span>
         <span slot="confirm">Stop downloads</span>
+      </Confirm>
+
+      <Confirm let:confirm>
+        <button
+          class="uk-button uk-button-link url-action-btn uk-margin-auto-left clear-playlist"
+          class:uk-hidden={!hasFilesInPlaylist || hasDownloadingFiles}
+          data-testid="clear-playlist"
+          title="Clear playlist"
+          on:click={() => confirm(clearPlaylist)}
+          value="">Clear playlist
+        </button
+        >
+        <span slot="title">Clear all files in playlist</span>
+        <span slot="description">All files will be removed from playlist.</span>
+        <span slot="confirm">Clear playlist</span>
       </Confirm>
     </div>
     <div
@@ -347,11 +370,14 @@
     padding: 16px
 
     &:hover
-      .start-download, .stop-download, .load-file
+      .start-download, .stop-download, .load-file, .clear-playlist
         opacity: 1
 
-  .start-download, .stop-download, .load-file
+  .start-download, .stop-download, .load-file, .clear-playlist
       opacity: 0
+
+  .clear-playlist
+    color: var(--danger-color)
 
   .playlist-toolbar
     gap: 4px

--- a/components/restreamer/client/src/components/Restream.svelte
+++ b/components/restreamer/client/src/components/Restream.svelte
@@ -107,10 +107,6 @@
   $: currentlyPlayingFile =
     isPlaylistPlaying && $playingFile.data?.currentlyPlayingFile;
 
-  $: {
-    console.log('CURRENTLY_PLAYING_FILE: ', currentlyPlayingFile);
-  }
-
   async function removeRestream() {
     try {
       await removeRestreamMutation({ variables: { id: value.id } });
@@ -239,14 +235,14 @@
         hidden={isFullView}
         target="_blank"
         rel="noreferrer"
-        class="uk-text-uppercase uk-text-small uk-margin-right"
+        class="uk-text-uppercase full-view-link"
         title="Open Full Stream Page"
       >
         Full view
       </a>
       <div class="uk-flex uk-flex-middle">
         <span
-          class="playlist-icon uk-margin-right"
+          class="playlist-icon uk-margin-right uk-margin-small-left uk-flex uk-flex-middle"
           class:is-playing={isPlaylistPlaying}
           aria-hidden="true"
           hidden={!hasVideos || isFullView}
@@ -388,7 +384,7 @@
       display: none
 
     &:hover
-      .uk-close, .edit-input, .export-import, .uk-button-small
+      .uk-close, .edit-input, .export-import, .uk-button-small, .full-view-link
         opacity: 1
 
     .uk-button-small
@@ -405,6 +401,11 @@
 
       &:hover
         opacity: 1
+
+    .full-view-link
+      font-size: 0.8rem
+      transition: opacity .3s ease
+      opacity: 0
 
     .edit-input, .export-import
       color: #666
@@ -462,6 +463,6 @@
       &.is-playing
         color: var(--success-color)
       :global(svg)
-        width: 24px
-        height: 24px
+        width: 20px
+        height: 20px
 </style>

--- a/components/restreamer/dashboard.graphql.schema.json
+++ b/components/restreamer/dashboard.graphql.schema.json
@@ -378,6 +378,18 @@
             "deprecationReason": null
           },
           {
+            "name": "removeAllClients",
+            "description": "Remove all [`Client`]s from dashboard",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "consoleClear",
             "description": "Remove all messages from console",
             "args": [],

--- a/components/restreamer/dashboard.graphql.schema.json
+++ b/components/restreamer/dashboard.graphql.schema.json
@@ -131,6 +131,17 @@
         "possibleTypes": null
       },
       {
+        "kind": "SCALAR",
+        "name": "FileId",
+        "description": "Identity of file on `Google Drive`.",
+        "specifiedByUrl": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "__InputValue",
         "description": null,
@@ -393,6 +404,60 @@
             "name": "consoleClear",
             "description": "Remove all messages from console",
             "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "broadcastPlayFile",
+            "description": "Start playing specific file on any of client",
+            "args": [
+              {
+                "name": "fileId",
+                "description": "File identity",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "FileId",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "broadcastStopPlayingFile",
+            "description": "Stop playing specific file on any of client",
+            "args": [
+              {
+                "name": "fileId",
+                "description": "File identity",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "FileId",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",

--- a/components/restreamer/src/api/graphql/client.rs
+++ b/components/restreamer/src/api/graphql/client.rs
@@ -241,6 +241,7 @@ impl MutationsRoot {
                 enabled: true,
             },
             outputs: vec![],
+            playlist: spec::v1::Playlist { queue: vec![] },
         };
 
         let result = if let Some(id) = id {

--- a/components/restreamer/src/api/graphql/client.rs
+++ b/components/restreamer/src/api/graphql/client.rs
@@ -103,7 +103,8 @@ impl MutationsRoot {
                         )
                 })?;
 
-            // If we import one input into another than we need to make imported key unique
+            // If we import one input into another than we need to make
+            // imported key unique
             let has_duplicate = context
                 .state()
                 .restreams
@@ -112,13 +113,16 @@ impl MutationsRoot {
                 .any(|r| r.key == spec.key);
 
             if has_duplicate {
-                if let Some(new_key) = RestreamKey::new(format!("{}1", spec.key)) {
+                if let Some(new_key) =
+                    RestreamKey::new(format!("{}1", spec.key))
+                {
                     spec.key = new_key;
                 } else {
-                     return Err(graphql::Error::new("INVALID_SPEC")
+                    return Err(graphql::Error::new("INVALID_SPEC")
                         .status(StatusCode::BAD_REQUEST)
                         .message(
-                            "Can not make new RestreamKey unique. Try to fix it manually",
+                            "Can not make new RestreamKey unique.\
+                             Try to fix it manually",
                         ));
                 }
             }

--- a/components/restreamer/src/api/graphql/client.rs
+++ b/components/restreamer/src/api/graphql/client.rs
@@ -621,12 +621,11 @@ impl MutationsRoot {
             .lock_mut()
             .iter_mut()
             .for_each(|r| {
-                let found =
-                    r.playlist.queue.iter().find(|f| f.file_id == file_id);
-
-                if found.is_some() {
-                    r.playlist.currently_playing_file = None;
-                    has_found = true;
+                if let Some(f) = r.playlist.currently_playing_file.clone() {
+                    if f.file_id == file_id {
+                        r.playlist.currently_playing_file = None;
+                        has_found = true;
+                    }
                 }
             });
 

--- a/components/restreamer/src/api/graphql/client.rs
+++ b/components/restreamer/src/api/graphql/client.rs
@@ -644,7 +644,7 @@ impl MutationsRoot {
                         .message("Could not find restream with provided ID")
                 })?
                 .playlist
-                .apply(playlist_files);
+                .apply(playlist_files, true);
 
             let mut commands = context.state().file_commands.lock_mut();
             commands.push(FileCommand::ListOfFilesChanged);

--- a/components/restreamer/src/api/graphql/dashboard.rs
+++ b/components/restreamer/src/api/graphql/dashboard.rs
@@ -106,6 +106,17 @@ impl MutationsRoot {
         Ok(Some(true))
     }
 
+    /// Stop playing specific file on any of client
+    fn broadcast_stop_playing_file(
+        #[graphql(description = "File identity")] file_id: FileId,
+        context: &Context,
+    ) -> Result<Option<bool>, graphql::Error> {
+        let mut commands = context.state().dashboard_commands.lock_mut();
+        commands.push(DashboardCommand::StopPlayingFile(file_id));
+
+        Ok(Some(true))
+    }
+
     /// Enables all `Output`s for all clients.
     fn enable_all_outputs_for_clients(
         context: &Context,

--- a/components/restreamer/src/api/graphql/dashboard.rs
+++ b/components/restreamer/src/api/graphql/dashboard.rs
@@ -7,6 +7,7 @@ use crate::{
     api::graphql,
     broadcaster::DashboardCommand,
     console_logger::ConsoleMessage,
+    file_manager::FileId,
     state::{Client, ClientId},
 };
 use actix_web::http::StatusCode;
@@ -76,12 +77,31 @@ impl MutationsRoot {
         }
     }
 
+    /// Remove all [`Client`]s from dashboard
+    fn remove_all_clients(
+        context: &Context,
+    ) -> Result<Option<bool>, graphql::Error> {
+        context.state().clients.lock_mut().clear();
+
+        Ok(Some(true))
+    }
+
     /// Remove all messages from console
     fn console_clear(
         context: &Context,
     ) -> Result<Option<bool>, graphql::Error> {
-        let mut console_log = context.state().console_log.lock_mut();
-        console_log.clear();
+        context.state().console_log.lock_mut().clear();
+
+        Ok(Some(true))
+    }
+
+    /// Start playing specific file on any of client
+    fn broadcast_play_file(
+        #[graphql(description = "File identity")] file_id: FileId,
+        context: &Context,
+    ) -> Result<Option<bool>, graphql::Error> {
+        let mut commands = context.state().dashboard_commands.lock_mut();
+        commands.push(DashboardCommand::StartPlayingFile(file_id));
 
         Ok(Some(true))
     }

--- a/components/restreamer/src/api/graphql/queries/play_file.graphql
+++ b/components/restreamer/src/api/graphql/queries/play_file.graphql
@@ -1,3 +1,0 @@
-mutation BroadcastPlayFile($fileId: String!) {
-    broadcastPlayFile(fileId: $fileId)
-}

--- a/components/restreamer/src/api/graphql/queries/start_playing_file.graphql
+++ b/components/restreamer/src/api/graphql/queries/start_playing_file.graphql
@@ -1,0 +1,3 @@
+mutation StartPlayingFile($fileId: FileId!) {
+    broadcastPlayFile(fileId: $fileId)
+}

--- a/components/restreamer/src/api/graphql/queries/stop_playing_file.graphql
+++ b/components/restreamer/src/api/graphql/queries/stop_playing_file.graphql
@@ -1,3 +1,3 @@
-mutation StopPlayingFile($fileId: String!) {
+mutation StopPlayingFile($fileId: FileId!) {
     broadcastStopPlayingFile(fileId: $fileId)
 }

--- a/components/restreamer/src/broadcaster.rs
+++ b/components/restreamer/src/broadcaster.rs
@@ -27,6 +27,9 @@ pub enum DashboardCommand {
     /// Command for initiation playing specific file on any of registered
     /// client
     StartPlayingFile(FileId),
+    /// Command for stop playing specific file on any of registered
+    /// client
+    StopPlayingFile(FileId),
 }
 
 /// GraphQL mutation for enabling outputs
@@ -58,6 +61,16 @@ pub(crate) struct DisableAllOutputsOfRestreams;
 )]
 #[derive(Debug)]
 pub(crate) struct StartPlayingFile;
+
+/// GraphQL mutation for stop playing file
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "client.graphql.schema.json",
+    query_path = "src/api/graphql/queries/stop_playing_file.graphql",
+    response_derives = "Debug"
+)]
+#[derive(Debug)]
+pub(crate) struct StopPlayingFile;
 
 /// Broadcast [`DashboardCommand`] to clients
 #[derive(Debug, Default)]
@@ -135,6 +148,19 @@ impl Broadcaster {
                     },
                 );
             }
+            DashboardCommand::StopPlayingFile(file_id) => {
+                let state = self.state.clone();
+                Self::try_to_run_command(
+                    client_id.clone(),
+                    state.clone(),
+                    async move {
+                        Self::request_stop_playing_file(
+                            client_id, &file_id, state,
+                        )
+                        .await
+                    },
+                );
+            }
         }
     }
 
@@ -191,6 +217,34 @@ impl Broadcaster {
 
         let response: Response<ResponseData> = res.json().await?;
         tracing::info!(?response, "Enabling outputs on client",);
+
+        Self::handle_errors(&client_id, &state, response.errors);
+        Ok(())
+    }
+
+    async fn request_stop_playing_file(
+        client_id: ClientId,
+        file_id: &FileId,
+        state: State,
+    ) -> anyhow::Result<()> {
+        type Vars = <StopPlayingFile as GraphQLQuery>::Variables;
+        type ResponseData = <StopPlayingFile as GraphQLQuery>::ResponseData;
+
+        let request_body = StopPlayingFile::build_query(Vars {
+            file_id: file_id.clone(),
+        });
+
+        let request = reqwest::Client::builder().build().unwrap();
+
+        let url = format!("{client_id}api");
+        let res = request
+            .post(url.as_str())
+            .json(&request_body)
+            .send()
+            .await?;
+
+        let response: Response<ResponseData> = res.json().await?;
+        tracing::info!(?response, "Stop playing file {file_id}",);
 
         Self::handle_errors(&client_id, &state, response.errors);
         Ok(())

--- a/components/restreamer/src/broadcaster.rs
+++ b/components/restreamer/src/broadcaster.rs
@@ -3,6 +3,7 @@
 use crate::{
     console_logger::{ConsoleLogger, ConsoleMessageKind, ConsoleMessageSource},
     display_panic,
+    file_manager::FileId,
     state::ClientId,
     State,
 };
@@ -23,6 +24,9 @@ pub enum DashboardCommand {
     EnableAllOutputs(),
     /// Command for disabling all restreams' outputs
     DisableAllOutputs(),
+    /// Command for initiation playing specific file on any of registered
+    /// client
+    StartPlayingFile(FileId),
 }
 
 /// GraphQL mutation for enabling outputs
@@ -44,6 +48,16 @@ pub(crate) struct EnableAllOutputsOfRestreams;
 )]
 #[derive(Debug)]
 pub(crate) struct DisableAllOutputsOfRestreams;
+
+/// GraphQL mutation for start playing file
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "client.graphql.schema.json",
+    query_path = "src/api/graphql/queries/start_playing_file.graphql",
+    response_derives = "Debug"
+)]
+#[derive(Debug)]
+pub(crate) struct StartPlayingFile;
 
 /// Broadcast [`DashboardCommand`] to clients
 #[derive(Debug, Default)]
@@ -77,10 +91,7 @@ impl Broadcaster {
             .filter(|client| client.is_protected)
             .for_each(|client| {
                 for command in &commands {
-                    self.handle_one_command(
-                        client.id.clone(),
-                        &command.clone(),
-                    );
+                    self.handle_one_command(client.id.clone(), command.clone());
                 }
             });
     }
@@ -88,7 +99,7 @@ impl Broadcaster {
     fn handle_one_command(
         &mut self,
         client_id: ClientId,
-        command: &DashboardCommand,
+        command: DashboardCommand,
     ) {
         match command {
             DashboardCommand::EnableAllOutputs() => {
@@ -108,6 +119,19 @@ impl Broadcaster {
                     state.clone(),
                     async move {
                         Self::request_disable_outputs(client_id, state).await
+                    },
+                );
+            }
+            DashboardCommand::StartPlayingFile(file_id) => {
+                let state = self.state.clone();
+                Self::try_to_run_command(
+                    client_id.clone(),
+                    state.clone(),
+                    async move {
+                        Self::request_start_playing_file(
+                            client_id, &file_id, state,
+                        )
+                        .await
                     },
                 );
             }
@@ -167,6 +191,34 @@ impl Broadcaster {
 
         let response: Response<ResponseData> = res.json().await?;
         tracing::info!(?response, "Enabling outputs on client",);
+
+        Self::handle_errors(&client_id, &state, response.errors);
+        Ok(())
+    }
+
+    async fn request_start_playing_file(
+        client_id: ClientId,
+        file_id: &FileId,
+        state: State,
+    ) -> anyhow::Result<()> {
+        type Vars = <StartPlayingFile as GraphQLQuery>::Variables;
+        type ResponseData = <StartPlayingFile as GraphQLQuery>::ResponseData;
+
+        let request_body = StartPlayingFile::build_query(Vars {
+            file_id: file_id.clone(),
+        });
+
+        let request = reqwest::Client::builder().build().unwrap();
+
+        let url = format!("{client_id}api");
+        let res = request
+            .post(url.as_str())
+            .json(&request_body)
+            .send()
+            .await?;
+
+        let response: Response<ResponseData> = res.json().await?;
+        tracing::info!(?response, "Start playing file {file_id}",);
 
         Self::handle_errors(&client_id, &state, response.errors);
         Ok(())

--- a/components/restreamer/src/file_manager.rs
+++ b/components/restreamer/src/file_manager.rs
@@ -15,6 +15,7 @@ use crate::{
     cli::Opts,
     display_panic,
     file_manager::api_response::{get_gdrive_result, ErrorResponse},
+    spec,
     state::{InputEndpointKind, InputSrc, State, Status},
     stream_probe::stream_probe,
     stream_statistics::StreamStatistics,
@@ -611,12 +612,13 @@ pub struct PlaylistFileInfo {
     pub was_played: bool,
 }
 
-impl From<api_response::ExtendedFileInfoResponse> for PlaylistFileInfo {
+impl From<api_response::ExtendedFileInfoResponse>
+    for spec::v1::PlaylistFileInfo
+{
     fn from(file_response: api_response::ExtendedFileInfoResponse) -> Self {
-        PlaylistFileInfo {
+        spec::v1::PlaylistFileInfo {
             file_id: FileId(file_response.id),
             name: file_response.name,
-            was_played: false,
         }
     }
 }
@@ -701,7 +703,7 @@ impl NetworkByteSize {
 pub async fn get_video_list_from_gdrive_folder(
     api_key: &str,
     folder_id: &str,
-) -> Result<Vec<PlaylistFileInfo>, String> {
+) -> Result<Vec<spec::v1::PlaylistFileInfo>, String> {
     let mut response =
         api_response::FileListResponse::retrieve_dir_content_from_api(
             api_key, folder_id,
@@ -711,7 +713,10 @@ pub async fn get_video_list_from_gdrive_folder(
     Ok(response
         .files
         .drain(..)
-        .map(PlaylistFileInfo::from)
+        .map(|x| spec::v1::PlaylistFileInfo {
+            file_id: FileId(x.id),
+            name: x.name,
+        })
         .collect())
 }
 

--- a/components/restreamer/src/spec/v1.rs
+++ b/components/restreamer/src/spec/v1.rs
@@ -94,6 +94,9 @@ pub struct Restream {
         skip_serializing_if = "Vec::is_empty"
     )]
     pub outputs: Vec<Output>,
+
+    /// Playlist for this restream
+    pub playlist: Playlist,
 }
 
 impl Restream {
@@ -439,4 +442,36 @@ pub struct BackupInput {
     /// URL to pull a live stream from for a backup endpoint.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub src: Option<state::InputSrcUrl>,
+}
+
+// Playlist
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Playlist {
+    /// List of files in playlist
+    pub queue: Vec<PlaylistFileInfo>,
+}
+
+impl Playlist {
+    #[must_use]
+    pub fn new(playlist: state::Playlist) -> Playlist {
+        Self {
+            queue: playlist
+                .queue
+                .into_iter()
+                .map(|x| PlaylistFileInfo {
+                    name: x.name,
+                    file_id: x.file_id,
+                })
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlaylistFileInfo {
+    /// Google ID of this file
+    pub file_id: FileId,
+
+    /// Name of this file
+    pub name: String,
 }

--- a/components/restreamer/src/spec/v1.rs
+++ b/components/restreamer/src/spec/v1.rs
@@ -2,7 +2,6 @@
 //! application's [`State`].
 //!
 //! [`State`]: state::State
-
 use std::collections::HashSet;
 
 use crate::{file_manager::FileId, serde::is_false, state, types::UNumber};
@@ -470,7 +469,7 @@ impl Playlist {
 }
 
 /// Shareable (exportable and importable) specification of a
-/// [`state::PlaylistFileInfo`]
+/// [`PlaylistFileInfo`]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PlaylistFileInfo {
     /// Google ID of this file

--- a/components/restreamer/src/spec/v1.rs
+++ b/components/restreamer/src/spec/v1.rs
@@ -444,7 +444,7 @@ pub struct BackupInput {
     pub src: Option<state::InputSrcUrl>,
 }
 
-// Playlist
+/// Shareable (exportable and importable) specification of a [`state::Playlist`]
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Playlist {
     /// List of files in playlist
@@ -452,6 +452,8 @@ pub struct Playlist {
 }
 
 impl Playlist {
+    /// Creates a new [`Playlist`] out of the given
+    /// [`state::Playlist`].
     #[must_use]
     pub fn new(playlist: state::Playlist) -> Playlist {
         Self {
@@ -467,6 +469,8 @@ impl Playlist {
     }
 }
 
+/// Shareable (exportable and importable) specification of a
+/// [`state::PlaylistFileInfo`]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PlaylistFileInfo {
     /// Google ID of this file

--- a/components/restreamer/src/state.rs
+++ b/components/restreamer/src/state.rs
@@ -1024,6 +1024,7 @@ pub struct Playlist {
 }
 
 impl Playlist {
+    /// Creates new [`Playlist`] from spec
     #[must_use]
     pub fn new(spec: spec::v1::Playlist) -> Playlist {
         let mut playlist = Self {
@@ -1045,7 +1046,6 @@ impl Playlist {
         if replace {
             self.queue = queue_spec
                 .into_iter()
-                .clone()
                 .map(|x| PlaylistFileInfo {
                     file_id: x.file_id,
                     name: x.name,
@@ -1059,7 +1059,7 @@ impl Playlist {
                         file_id,
                         name,
                         was_played: false,
-                    })
+                    });
                 }
             }
         }

--- a/components/restreamer/src/state.rs
+++ b/components/restreamer/src/state.rs
@@ -1024,10 +1024,46 @@ pub struct Playlist {
 }
 
 impl Playlist {
+    #[must_use]
+    pub fn new(spec: spec::v1::Playlist) -> Playlist {
+        let mut playlist = Self {
+            id: PlaylistId::random(),
+            queue: vec![],
+            currently_playing_file: None,
+        };
+
+        playlist.apply(spec.queue);
+        playlist
+    }
+
     /// Apply new playlist to this one
-    pub fn apply(&mut self, queue: Vec<PlaylistFileInfo>) {
-        self.queue = queue;
+    pub fn apply(&mut self, queue: Vec<spec::v1::PlaylistFileInfo>) {
+        self.queue = queue
+            .into_iter()
+            .clone()
+            .map(|x| PlaylistFileInfo {
+                file_id: x.file_id,
+                name: x.name,
+                was_played: false,
+            })
+            .collect();
         self.currently_playing_file = None;
+    }
+
+    /// Exports this [`Playlist`] as a [`spec::v1::Playlist`].
+    #[must_use]
+    pub fn export(&self) -> spec::v1::Playlist {
+        spec::v1::Playlist {
+            queue: self
+                .queue
+                .clone()
+                .into_iter()
+                .map(|x| spec::v1::PlaylistFileInfo {
+                    name: x.name,
+                    file_id: x.file_id,
+                })
+                .collect(),
+        }
     }
 }
 

--- a/components/restreamer/src/state.rs
+++ b/components/restreamer/src/state.rs
@@ -1032,21 +1032,43 @@ impl Playlist {
             currently_playing_file: None,
         };
 
-        playlist.apply(spec.queue);
+        playlist.apply(spec.queue, true);
         playlist
     }
 
     /// Apply new playlist to this one
-    pub fn apply(&mut self, queue: Vec<spec::v1::PlaylistFileInfo>) {
-        self.queue = queue
-            .into_iter()
-            .clone()
-            .map(|x| PlaylistFileInfo {
-                file_id: x.file_id,
-                name: x.name,
-                was_played: false,
-            })
-            .collect();
+    pub fn apply(
+        &mut self,
+        queue_spec: Vec<spec::v1::PlaylistFileInfo>,
+        replace: bool,
+    ) {
+        if replace {
+            self.queue = queue_spec
+                .into_iter()
+                .clone()
+                .map(|x| PlaylistFileInfo {
+                    file_id: x.file_id,
+                    name: x.name,
+                    was_played: false,
+                })
+                .collect();
+        } else {
+            for spec::v1::PlaylistFileInfo { file_id, name } in queue_spec {
+                if self
+                    .queue
+                    .clone()
+                    .into_iter()
+                    .find(|x| x.file_id == file_id)
+                    .is_none()
+                {
+                    self.queue.push(PlaylistFileInfo {
+                        file_id,
+                        name,
+                        was_played: false,
+                    })
+                }
+            }
+        }
         self.currently_playing_file = None;
     }
 

--- a/components/restreamer/src/state.rs
+++ b/components/restreamer/src/state.rs
@@ -1054,13 +1054,7 @@ impl Playlist {
                 .collect();
         } else {
             for spec::v1::PlaylistFileInfo { file_id, name } in queue_spec {
-                if self
-                    .queue
-                    .clone()
-                    .into_iter()
-                    .find(|x| x.file_id == file_id)
-                    .is_none()
-                {
+                if !self.queue.iter().any(|x| x.file_id == file_id) {
                     self.queue.push(PlaylistFileInfo {
                         file_id,
                         name,

--- a/components/restreamer/src/state/restream.rs
+++ b/components/restreamer/src/state/restream.rs
@@ -67,6 +67,7 @@ impl Restream {
         self.key = new.key;
         self.label = new.label;
         self.input.apply(new.input);
+        self.playlist.apply(new.playlist.queue, replace);
         if replace {
             let mut olds = mem::replace(
                 &mut self.outputs,

--- a/components/restreamer/src/state/restream.rs
+++ b/components/restreamer/src/state/restream.rs
@@ -54,11 +54,7 @@ impl Restream {
             label: spec.label,
             input: Input::new(spec.input),
             outputs: spec.outputs.into_iter().map(Output::new).collect(),
-            playlist: Playlist {
-                id: PlaylistId::random(),
-                queue: vec![],
-                currently_playing_file: None,
-            },
+            playlist: Playlist::new(spec.playlist),
         }
     }
 
@@ -110,6 +106,7 @@ impl Restream {
             id: Some(self.id),
             key: self.key.clone(),
             label: self.label.clone(),
+            playlist: self.playlist.export(),
             input: self.input.export(),
             outputs: self.outputs.iter().map(Output::export).collect(),
         }

--- a/components/restreamer/src/state/restream.rs
+++ b/components/restreamer/src/state/restream.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use crate::{
     spec,
-    state::{Input, Label, Output, Playlist, PlaylistId},
+    state::{Input, Label, Output, Playlist},
 };
 
 /// Re-stream of a live stream from one `Input` to many `Output`s.


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- New Feature: Added `FileId` scalar type and several new dashboard APIs to the GraphQL schema.
- Bug fix: Fixed import errors and restored visibility of sound mixer for parent restream in various files.
- Refactor: Modified code logic and functionality in several files, including adding new mutations and functions.
- Style: Updated CSS styles and UI elements in `AppFullStream.svelte` and `Playlist.svelte`.
- Test: Added an empty playlist queue to each object in the JSON configuration file.

> "Bug fixes and new features galore,
> Restreamer's code is better than before.
> With updated FFmpeg and GraphQL too,
> This PR brings improvements through and through."
<!-- end of auto-generated comment: release notes by openai -->