### PR TITLE
Make Playlist optional

### DIFF
--- a/components/restreamer/CHANGELOG.md
+++ b/components/restreamer/CHANGELOG.md
@@ -23,6 +23,7 @@ All user visible changes to this project will be documented in this file. This p
   - Star/Stop playing file ([#386])
 - Playlist
   - Status component ([#343], [#348])
+  - Make playlist optional on import ([#405])
 
 ### Miscellaneous
 - Update [FFmpeg] to 6.0  ([#375]);
@@ -36,6 +37,7 @@ All user visible changes to this project will be documented in this file. This p
 [#374]: /../../pull/374
 [#375]: /../../pull/375
 [#386]: /../../pull/386
+[#405]: /../../pull/405
 
 
 

--- a/components/restreamer/src/api/graphql/client.rs
+++ b/components/restreamer/src/api/graphql/client.rs
@@ -273,7 +273,7 @@ impl MutationsRoot {
                 enabled: true,
             },
             outputs: vec![],
-            playlist: spec::v1::Playlist { queue: vec![] },
+            playlist: Some(spec::v1::Playlist { queue: vec![] }),
         };
 
         let result = if let Some(id) = id {

--- a/components/restreamer/src/spec/v1.rs
+++ b/components/restreamer/src/spec/v1.rs
@@ -95,7 +95,7 @@ pub struct Restream {
     pub outputs: Vec<Output>,
 
     /// Playlist for this restream
-    pub playlist: Playlist,
+    pub playlist: Option<Playlist>,
 }
 
 impl Restream {

--- a/components/restreamer/src/state.rs
+++ b/components/restreamer/src/state.rs
@@ -1026,14 +1026,17 @@ pub struct Playlist {
 impl Playlist {
     /// Creates new [`Playlist`] from spec
     #[must_use]
-    pub fn new(spec: spec::v1::Playlist) -> Playlist {
+    pub fn new(spec: Option<spec::v1::Playlist>) -> Playlist {
         let mut playlist = Self {
             id: PlaylistId::random(),
             queue: vec![],
             currently_playing_file: None,
         };
 
-        playlist.apply(spec.queue, true);
+        if let Some(s) = spec {
+            playlist.apply(s.queue, true);
+        }
+
         playlist
     }
 

--- a/components/restreamer/src/state/restream.rs
+++ b/components/restreamer/src/state/restream.rs
@@ -67,7 +67,11 @@ impl Restream {
         self.key = new.key;
         self.label = new.label;
         self.input.apply(new.input);
-        self.playlist.apply(new.playlist.queue, replace);
+
+        if let Some(p) = new.playlist {
+            self.playlist.apply(p.queue, replace);
+        }
+
         if replace {
             let mut olds = mem::replace(
                 &mut self.outputs,
@@ -107,7 +111,7 @@ impl Restream {
             id: Some(self.id),
             key: self.key.clone(),
             label: self.label.clone(),
-            playlist: self.playlist.export(),
+            playlist: Some(self.playlist.export()),
             input: self.input.export(),
             outputs: self.outputs.iter().map(Output::export).collect(),
         }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:
- New Feature: Make playlist optional on import
- Refactor: Modify `playlist` field to be optional in multiple files

> A new feature has arrived,
> Making playlists optional with pride.
> Refactored code, safe and sound,
> Improving the codebase all around.
<!-- end of auto-generated comment: release notes by openai -->