### PR TITLE
Replace `structopt` with `clap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "f728064aca1c318585bf4bb04ffcfac9e75e508ab4e8b1bd9ba5dfe04e2cbed5"
 dependencies = [
  "actix-rt",
  "actix_derive",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "crossbeam-channel 0.5.8",
  "futures-core",
@@ -32,7 +32,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617a8268e3537fe1d8c9ead925fca49ef6400927ee7bc26750e90ecee14ce4b8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -55,7 +55,7 @@ dependencies = [
  "actix-utils",
  "ahash 0.8.3",
  "base64 0.21.2",
- "bitflags",
+ "bitflags 1.3.2",
  "brotli",
  "bytes",
  "bytestring",
@@ -371,12 +371,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "anstream"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
 dependencies = [
- "winapi",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -518,17 +558,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "audiopus"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,7 +599,7 @@ checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "http",
@@ -671,6 +700,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "bitvec"
@@ -854,18 +889,44 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
 ]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.10.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.63",
+ "quote 1.0.28",
+ "syn 2.0.22",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "cloudabi"
@@ -873,7 +934,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -886,6 +947,12 @@ dependencies = [
  "dbl",
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "combine"
@@ -1407,7 +1474,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "570d109b813e904becc80d8d5da38376818a143348413f7149f1340fe04754d4"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2 1.0.63",
  "quote 1.0.28",
  "syn 1.0.109",
@@ -1419,7 +1486,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2 1.0.63",
  "quote 1.0.28",
  "syn 1.0.109",
@@ -1494,6 +1561,7 @@ dependencies = [
  "backoff",
  "byteorder",
  "chrono",
+ "clap",
  "derive_more",
  "ephyr-api-google-drive",
  "ephyr-log",
@@ -1509,6 +1577,7 @@ dependencies = [
  "juniper",
  "juniper_actix",
  "juniper_graphql_ws",
+ "lazy_static",
  "libc",
  "nix",
  "num_cpus",
@@ -1523,7 +1592,6 @@ dependencies = [
  "serde_json",
  "smart-default",
  "static-files",
- "structopt",
  "systemstat",
  "tap",
  "tokio",
@@ -1902,7 +1970,7 @@ checksum = "a40f793251171991c4eb75bd84bc640afa8b68ff6907bc89d3b712a22f700506"
 dependencies = [
  "graphql-introspection-query",
  "graphql-parser",
- "heck 0.4.1",
+ "heck",
  "lazy_static",
  "proc-macro2 1.0.63",
  "quote 1.0.28",
@@ -1966,27 +2034,9 @@ checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -2297,6 +2347,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "rustix 0.38.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2432,7 +2493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec 0.5.2",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "ryu",
  "static_assertions",
@@ -2455,6 +2516,12 @@ name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "local-channel"
@@ -2657,7 +2724,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "libc",
  "memoffset 0.7.1",
@@ -2786,7 +2853,7 @@ version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -3139,7 +3206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck",
  "itertools 0.10.5",
  "lazy_static",
  "log",
@@ -3440,7 +3507,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3449,7 +3516,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3594,11 +3661,24 @@ version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.5",
  "windows-sys 0.48.0",
 ]
 
@@ -3649,7 +3729,7 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3916,39 +3996,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
+name = "strsim"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2 1.0.63",
- "quote 1.0.28",
- "syn 1.0.109",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -4043,17 +4099,8 @@ dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix",
+ "rustix 0.37.20",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -4559,7 +4606,7 @@ version = "0.1.0"
 source = "git+https://github.com/ReSpeak/tsclientlib?rev=3ae4a618dc348d36eeaabc8fa018a408112498d9#3ae4a618dc348d36eeaabc8fa018a408112498d9"
 dependencies = [
  "base64 0.13.1",
- "heck 0.4.1",
+ "heck",
  "itertools 0.10.5",
  "num-derive",
  "num-traits",
@@ -4608,7 +4655,7 @@ source = "git+https://github.com/ReSpeak/tsclientlib?rev=3ae4a618dc348d36eeaabc8
 dependencies = [
  "aes",
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "curve25519-dalek-ng",
  "eax",
  "futures",
@@ -4638,7 +4685,7 @@ version = "0.1.0"
 source = "git+https://github.com/ReSpeak/tsclientlib?rev=3ae4a618dc348d36eeaabc8fa018a408112498d9#3ae4a618dc348d36eeaabc8fa018a408112498d9"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "num-derive",
  "num-traits",
  "omnom",
@@ -4654,7 +4701,7 @@ source = "git+https://github.com/ReSpeak/tsclientlib?rev=3ae4a618dc348d36eeaabc8
 dependencies = [
  "base64 0.13.1",
  "csv",
- "heck 0.4.1",
+ "heck",
  "once_cell",
  "serde",
  "toml",
@@ -4666,11 +4713,11 @@ version = "0.1.0"
 source = "git+https://github.com/ReSpeak/tsclientlib?rev=3ae4a618dc348d36eeaabc8fa018a408112498d9#3ae4a618dc348d36eeaabc8fa018a408112498d9"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "curve25519-dalek-ng",
  "elliptic-curve",
  "generic-array",
- "heck 0.4.1",
+ "heck",
  "num-bigint",
  "num-derive",
  "num-traits",
@@ -4723,18 +4770,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4760,6 +4795,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
@@ -4800,12 +4841,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/components/restreamer/Cargo.toml
+++ b/components/restreamer/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_humantime = { version = "1.0", package = "humantime-serde" }
 serde_json = "1.0"
 smart-default = "0.7"
-structopt = "0.3"
+clap = { version = "4", features = ["derive", "env"] }
 systemstat = "0.2"
 tap = "1.0.1"
 url = { version = "2.1", features = ["serde"] }
@@ -46,6 +46,7 @@ uuid = { version = "1.1", features = ["serde", "v4"] }
 zeromq = "0.3"
 interprocess = { version = "1.2", features = ["tokio_support"] }
 tokio-stream = { version="0.1", features = ["fs"]}
+lazy_static = "1.4"
 [dependencies.tsclientlib]
     git = "https://github.com/ReSpeak/tsclientlib"
     rev = "3ae4a618dc348d36eeaabc8fa018a408112498d9" # branch = "master"

--- a/components/restreamer/src/bin/export_schema.rs
+++ b/components/restreamer/src/bin/export_schema.rs
@@ -9,13 +9,13 @@
 use std::{fs, path::PathBuf, str::FromStr};
 
 use anyhow::anyhow;
+use clap::Parser;
 use derive_more::Display;
 use ephyr_restreamer::api;
-use structopt::StructOpt;
 
 /// Introspects GraphQL schema and exports it into `*.graphql.schema.json` file.
 fn main() -> anyhow::Result<()> {
-    let opts = CliOpts::from_args_safe()?;
+    let opts = CliOpts::parse();
 
     let err_fn = |e| anyhow!("Failed to execute introspection query: {e}");
 
@@ -68,14 +68,14 @@ fn main() -> anyhow::Result<()> {
 }
 
 /// CLI (command line interface) of this binary.
-#[derive(Clone, Debug, StructOpt)]
-#[structopt(
+#[derive(Clone, Debug, Parser)]
+#[command(
     about = "Export GraphQL schema to a JSON file",
     rename_all = "kebab-case"
 )]
 struct CliOpts {
     /// [`api::graphql`] to export schema of.
-    #[structopt(
+    #[arg(
         long,
         default_value = "client",
         help = "Backend API to export schema of: client"
@@ -85,7 +85,7 @@ struct CliOpts {
     /// Output directory to create JSON file in.
     ///
     /// [`vod::meta::State`]: crate::vod::meta::State
-    #[structopt(
+    #[arg(
         long,
         default_value = "./components/restreamer/",
         help = "Output directory to create JSON file in"

--- a/components/restreamer/src/cli.rs
+++ b/components/restreamer/src/cli.rs
@@ -1,20 +1,19 @@
 //! CLI (command line interface).
 
+use clap::Parser;
+use ephyr_log::tracing;
 use std::{fmt, net::IpAddr, path::PathBuf, str::FromStr as _};
 
-use ephyr_log::tracing;
-use structopt::StructOpt;
-
 /// CLI (command line interface) of the re-streamer server.
-#[derive(Clone, Debug, StructOpt)]
-#[structopt(about = "RTMP re-streamer server")]
+#[derive(Clone, Debug, Parser)]
+#[command(about = "RTMP re-streamer server")]
 pub struct Opts {
     /// Debug mode of the server.
-    #[structopt(short, long, help = "Enables debug mode")]
+    #[arg(short, long, help = "Enables debug mode")]
     pub debug: bool,
 
     /// IP address for the server to listen client HTTP requests on.
-    #[structopt(
+    #[arg(
         long,
         env = "EPHYR_RESTREAMER_CLIENT_HTTP_IP",
         default_value = "0.0.0.0",
@@ -25,7 +24,7 @@ pub struct Opts {
     pub client_http_ip: IpAddr,
 
     /// Port for the server to listen client HTTP requests on.
-    #[structopt(
+    #[arg(
         long,
         env = "EPHYR_RESTREAMER_CLIENT_HTTP_PORT",
         default_value = "80",
@@ -35,7 +34,7 @@ pub struct Opts {
     pub client_http_port: u16,
 
     /// IP address for the server to listen RTMP callback HTTP requests on.
-    #[structopt(
+    #[arg(
         long,
         env = "EPHYR_RESTREAMER_CALLBACK_HTTP_IP",
         default_value = "127.0.0.1",
@@ -46,7 +45,7 @@ pub struct Opts {
     pub callback_http_ip: IpAddr,
 
     /// Port for the server to listen RTMP callback HTTP requests on.
-    #[structopt(
+    #[arg(
         long,
         env = "EPHYR_RESTREAMER_CALLBACK_HTTP_PORT",
         default_value = "8081",
@@ -57,7 +56,7 @@ pub struct Opts {
     pub callback_http_port: u16,
 
     /// Path to a file to persist the server's state in.
-    #[structopt(
+    #[arg(
         short,
         long,
         env = "EPHYR_RESTREAMER_STATE_PATH",
@@ -70,7 +69,7 @@ pub struct Opts {
     /// Path to [SRS] installation directory.
     ///
     /// [SRS]: https://github.com/ossrs/srs
-    #[structopt(
+    #[arg(
         long,
         env = "EPHYR_RESTREAMER_SRS_PATH",
         default_value = "/usr/local/srs",
@@ -86,7 +85,7 @@ pub struct Opts {
     /// current working directory.
     ///
     /// [SRS]: https://github.com/ossrs/srs
-    #[structopt(
+    #[arg(
         long,
         env = "EPHYR_RESTREAMER_SRS_HTTP_DIR",
         default_value = "/var/www/srs",
@@ -102,7 +101,7 @@ pub struct Opts {
     /// Path to [FFmpeg] binary.
     ///
     /// [FFmpeg]: https://ffmpeg.org
-    #[structopt(
+    #[arg(
         short,
         long,
         env = "FFMPEG_PATH",
@@ -115,7 +114,7 @@ pub struct Opts {
     /// Host to access the re-streamer server in public networks.
     ///
     /// If [`None`], then it will be auto-detected.
-    #[structopt(
+    #[arg(
         long,
         env = "EPHYR_RESTREAMER_PUBLIC_HOST",
         help = "Public host to access the server",
@@ -125,16 +124,16 @@ pub struct Opts {
     pub public_host: Option<String>,
 
     /// Verbosity level of the server logs.
-    #[structopt(
+    #[arg(
         short,
         long,
-        parse(try_from_str = tracing::Level::from_str),
+        value_parser(tracing::Level::from_str),
         help = "Logs verbosity level: INFO | DEBUG | TRACE"
     )]
     pub verbose: Option<tracing::Level>,
 
     /// Logs format for displaying.
-    #[structopt(
+    #[arg(
         short,
         long,
         env = "EPHYR_RESTREAMER_LOG_FORMAT",
@@ -143,7 +142,7 @@ pub struct Opts {
     pub log_format: Option<ephyr_log::LogFormat>,
 
     /// Path for local video files.
-    #[structopt(
+    #[arg(
         long,
         env = "EPHYR_RESTREAMER_VIDEO_FILE_ROOT",
         default_value = "/tmp/ephyr",
@@ -156,7 +155,7 @@ pub struct Opts {
     /// IP address of [OpenTelemetry] collector server to send logs to.
     ///
     /// [OpenTelemetry]: https://OpenTelemetry.io
-    #[structopt(
+    #[arg(
         long,
         env = "EPHYR_RESTREAMER_OTLP_COLLECTOR_IP",
         help = "IP of OTLP collector to send traces",
@@ -169,7 +168,7 @@ pub struct Opts {
     /// In our case as we send data with gRPC so port is typically `4317`.
     ///
     /// [OpenTelemetry]: https://OpenTelemetry.io
-    #[structopt(
+    #[arg(
         long,
         env = "EPHYR_RESTREAMER_OTLP_COLLECTOR_PORT",
         help = "Port of OTLP collector to send traces",
@@ -180,7 +179,7 @@ pub struct Opts {
     /// Service name to collect traces to [OpenTelemetry] collector.
     ///
     /// [OpenTelemetry]: https://OpenTelemetry.io
-    #[structopt(
+    #[arg(
         long,
         env = "EPHYR_RESTREAMER_SERVICE_NAME",
         default_value = "ephyr-restreamer",
@@ -197,7 +196,7 @@ impl Opts {
     #[inline]
     #[must_use]
     pub fn from_args() -> Self {
-        <Self as StructOpt>::from_args()
+        <Self as Parser>::parse()
     }
 }
 

--- a/components/restreamer/src/ffmpeg/restreamer_kind.rs
+++ b/components/restreamer/src/ffmpeg/restreamer_kind.rs
@@ -9,13 +9,13 @@ use ephyr_log::{
     tracing::{instrument, Instrument},
     ChildCapture, ParsedMsg, Span,
 };
+use lazy_static::lazy_static;
 use libc::pid_t;
 use regex::Regex;
 use std::{
     convert::TryInto, fmt::Display, os::unix::process::ExitStatusExt,
     path::Path, time::Duration,
 };
-use structopt::lazy_static::lazy_static;
 use tokio::{io, process::Command, sync::watch};
 use url::Url;
 use uuid::Uuid;

--- a/components/restreamer/src/srs.rs
+++ b/components/restreamer/src/srs.rs
@@ -15,6 +15,7 @@ use ephyr_log::{
     ChildCapture, ParsedMsg,
 };
 use futures::future::{self, FutureExt as _, TryFutureExt as _};
+use lazy_static::lazy_static;
 use regex::Regex;
 use smart_default::SmartDefault;
 use std::{
@@ -26,7 +27,6 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use structopt::lazy_static::lazy_static;
 use tokio::{fs, process::Command, sync::Mutex, time};
 
 /// [SRS] server spawnable as a separate process.


### PR DESCRIPTION
As [structopt docs state themselves](https://github.com/TeXitoi/structopt#maintenance), that crate is now in maintenance mode, as its features are now available in clap, which is actively maintained and is itself one of structopt's dependencies.
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- Refactor: Replaced the deprecated `structopt` crate with the `clap` crate for command-line argument parsing in the Rust program.
- New Feature: Added the `lazy_static` crate as a project dependency.
- Documentation: Updated import statements in multiple files to directly import from the `lazy_static` crate instead of through `structopt`.

> "From `structopt` to `clap`, 
> Command-line parsing got a revamp. 
> With `lazy_static` in tow, 
> Dependencies now smoothly flow. 
> Release notes sing, 
> Code improvements bring!"
<!-- end of auto-generated comment: release notes by openai -->