### PR TITLE
Drag & drop between outputs

### DIFF
--- a/components/restreamer/client.graphql.schema.json
+++ b/components/restreamer/client.graphql.schema.json
@@ -1804,7 +1804,7 @@
           },
           {
             "name": "moveOutput",
-            "description": "",
+            "description": "Moves `Output` specified by `scr_output_id` from parent `Intput` to\n`Restream` specified by `dst_restream_id` into `dst_position`\nAlso moving the `Output` become disabled.\n\n### Result\n\nReturns `true` if output was moved sucessfully",
             "args": [
               {
                 "name": "srcOutputId",

--- a/components/restreamer/client.graphql.schema.json
+++ b/components/restreamer/client.graphql.schema.json
@@ -1807,14 +1807,14 @@
             "description": "",
             "args": [
               {
-                "name": "srcRestreamId",
-                "description": "ID of the source parent `Restream`",
+                "name": "srcOutputId",
+                "description": "ID of the `Output` to be moved",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
-                    "name": "RestreamId",
+                    "name": "OutputId",
                     "ofType": null
                   }
                 },
@@ -1829,20 +1829,6 @@
                   "ofType": {
                     "kind": "SCALAR",
                     "name": "RestreamId",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "srcOutputId",
-                "description": "ID of the `Output` to be moved",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "OutputId",
                     "ofType": null
                   }
                 },

--- a/components/restreamer/client.graphql.schema.json
+++ b/components/restreamer/client.graphql.schema.json
@@ -1803,6 +1803,79 @@
             "deprecationReason": null
           },
           {
+            "name": "moveOutput",
+            "description": "",
+            "args": [
+              {
+                "name": "srcRestreamId",
+                "description": "ID of the source parent `Restream`",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "RestreamId",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "dstRestreamId",
+                "description": "ID of the destination parent `Restream`",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "RestreamId",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "srcOutputId",
+                "description": "ID of the `Output` to be moved",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "OutputId",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "dstPosition",
+                "description": "Position in destination array of `Output`s",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "UNumber",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "setPlaylist",
             "description": "Set playlist to [`Restream`]\n\n### Result\n\nReturns `true` if restream was found by `restream_id` and\nplaylist was set to it",
             "args": [

--- a/components/restreamer/client/api/client.graphql
+++ b/components/restreamer/client/api/client.graphql
@@ -88,6 +88,10 @@ mutation UpdateOutputsOrder($ids: [OutputId!]!, $restreamId: RestreamId!) {
     changeOutputsOrder(ids: $ids, restreamId: $restreamId)
 }
 
+mutation MoveOutput($srcRestreamId: RestreamId!, $dstRestreamId: RestreamId!, $srcOutputId: OutputId!, $dstPosition: UNumber!) {
+    moveOutput(srcRestreamId: $srcRestreamId, dstRestreamId: $dstRestreamId, srcOutputId: $srcOutputId, dstPosition: $dstPosition)
+}
+
 mutation SetRestream(
     $key: RestreamKey!
     $url: InputSrcUrl

--- a/components/restreamer/client/api/client.graphql
+++ b/components/restreamer/client/api/client.graphql
@@ -88,8 +88,16 @@ mutation UpdateOutputsOrder($ids: [OutputId!]!, $restreamId: RestreamId!) {
     changeOutputsOrder(ids: $ids, restreamId: $restreamId)
 }
 
-mutation MoveOutput($srcOutputId: OutputId!, $dstRestreamId: RestreamId!, $dstPosition: UNumber!) {
-    moveOutput(srcOutputId: $srcOutputId, dstRestreamId: $dstRestreamId, dstPosition: $dstPosition)
+mutation MoveOutput(
+    $srcOutputId: OutputId!
+    $dstRestreamId: RestreamId!
+    $dstPosition: UNumber!
+) {
+    moveOutput(
+        srcOutputId: $srcOutputId
+        dstRestreamId: $dstRestreamId
+        dstPosition: $dstPosition
+    )
 }
 
 mutation SetRestream(

--- a/components/restreamer/client/api/client.graphql
+++ b/components/restreamer/client/api/client.graphql
@@ -88,8 +88,8 @@ mutation UpdateOutputsOrder($ids: [OutputId!]!, $restreamId: RestreamId!) {
     changeOutputsOrder(ids: $ids, restreamId: $restreamId)
 }
 
-mutation MoveOutput($srcRestreamId: RestreamId!, $dstRestreamId: RestreamId!, $srcOutputId: OutputId!, $dstPosition: UNumber!) {
-    moveOutput(srcRestreamId: $srcRestreamId, dstRestreamId: $dstRestreamId, srcOutputId: $srcOutputId, dstPosition: $dstPosition)
+mutation MoveOutput($srcOutputId: OutputId!, $dstRestreamId: RestreamId!, $dstPosition: UNumber!) {
+    moveOutput(srcOutputId: $srcOutputId, dstRestreamId: $dstRestreamId, dstPosition: $dstPosition)
 }
 
 mutation SetRestream(

--- a/components/restreamer/client/src/components/All.svelte
+++ b/components/restreamer/client/src/components/All.svelte
@@ -50,7 +50,6 @@
 
   export let state;
   export let info;
-  export let files;
 
   const searchQueryKey = 'search';
   const filterQueryKey = 'filter_by';
@@ -469,7 +468,6 @@
         value={restream}
         hidden={globalInputsFilters?.length && !isReStreamVisible(restream)}
         {globalOutputsFilters}
-        {files}
       />
     {:else}
       <div

--- a/components/restreamer/client/src/components/AppRestreamer.svelte
+++ b/components/restreamer/client/src/components/AppRestreamer.svelte
@@ -1,7 +1,7 @@
 <script lang="js">
   import { createGraphQlClient } from '../utils/util';
 
-  import { Info, State, ServerInfo, Files } from '../../api/client.graphql';
+  import { Info, State, ServerInfo } from '../../api/client.graphql';
   import { setClient, subscribe } from 'svelte-apollo';
   import Shell from './common/Shell.svelte';
   import Toolbar from './Toolbar.svelte';
@@ -18,19 +18,15 @@
   const info = subscribe(Info, { errorPolicy: 'all' });
   const state = subscribe(State, { errorPolicy: 'all' });
   const serverInfo = subscribe(ServerInfo, { errorPolicy: 'all' });
-  const filesInfo = subscribe(Files, { errorPolicy: 'all' });
 
   $: canRenderToolbar = isOnline && $info.data;
   $: infoError = $info && $info.error;
   $: isLoading = !isOnline || $state.loading;
   $: canRenderMainComponent =
-    isOnline && $state.data && $info.data && $filesInfo.data;
+    isOnline && $state.data && $info.data;
   $: stateError = $state?.error;
   $: sInfo = $serverInfo?.data?.serverInfo;
   $: document.title = (isOnline ? '' : '🔴  ') + document.title;
-
-  $: filesError = $filesInfo?.error;
-  $: files = (canRenderMainComponent && $filesInfo?.data?.files) || [];
 </script>
 
 <template>
@@ -38,17 +34,16 @@
     {isLoading}
     {canRenderToolbar}
     {canRenderMainComponent}
-    error={stateError || infoError || filesError}
+    error={stateError || infoError}
     serverInfo={sInfo}
   >
     <Toolbar
       slot="toolbar"
       {info}
       {state}
-      {serverInfo}
       {isOnline}
       {gqlClient}
     />
-    <PageAll slot="main" {info} {state} {serverInfo} {files} />
+    <PageAll slot="main" {info} {state} />
   </Shell>
 </template>

--- a/components/restreamer/client/src/components/AppRestreamer.svelte
+++ b/components/restreamer/client/src/components/AppRestreamer.svelte
@@ -22,8 +22,7 @@
   $: canRenderToolbar = isOnline && $info.data;
   $: infoError = $info && $info.error;
   $: isLoading = !isOnline || $state.loading;
-  $: canRenderMainComponent =
-    isOnline && $state.data && $info.data;
+  $: canRenderMainComponent = isOnline && $state.data && $info.data;
   $: stateError = $state?.error;
   $: sInfo = $serverInfo?.data?.serverInfo;
   $: document.title = (isOnline ? '' : '🔴  ') + document.title;
@@ -37,13 +36,7 @@
     error={stateError || infoError}
     serverInfo={sInfo}
   >
-    <Toolbar
-      slot="toolbar"
-      {info}
-      {state}
-      {isOnline}
-      {gqlClient}
-    />
+    <Toolbar slot="toolbar" {info} {state} {isOnline} {gqlClient} />
     <PageAll slot="main" {info} {state} />
   </Shell>
 </template>

--- a/components/restreamer/client/src/components/Output.svelte
+++ b/components/restreamer/client/src/components/Output.svelte
@@ -145,7 +145,7 @@
             confirmFn={enableConfirmation ? confirm : undefined}
             onChangeFn={toggle}
           />
-          <span slot="title"
+          <span slot="title" class="output-name"
             >{toggleStatusText} <code>{value.dst}</code> output</span
           >
           <span slot="description">Are you sure about it?</span>
@@ -313,5 +313,10 @@
     margin-right: 4px
     cursor: grab
 
+  .output-name
+    overflow: hidden
+    text-overflow: ellipsis
+    display: inline-block
+    width: 100%
 
 </style>

--- a/components/restreamer/client/src/components/Playlist.svelte
+++ b/components/restreamer/client/src/components/Playlist.svelte
@@ -198,7 +198,7 @@
       </button>
       <Confirm let:confirm>
         <button
-          class="uk-button uk-button-link url-action-btn uk-margin-small-left start-download"
+          class="uk-button uk-button-link url-action-btn start-download"
           class:uk-hidden={!hasFilesInPlaylist || hasDownloadingFiles}
           data-testid="start-all-outputs"
           title="Start all incomplete downloads of files in the playlist"
@@ -215,7 +215,7 @@
 
       <Confirm let:confirm>
         <button
-          class="uk-button uk-button-link url-action-btn uk-margin-small-left stop-download"
+          class="uk-button uk-button-link url-action-btn stop-download"
           class:uk-hidden={!hasFilesInPlaylist || !hasDownloadingFiles}
           data-testid="stop-all-outputs"
           title="Stop all downloads of all files in the playlist"

--- a/components/restreamer/client/src/components/Restream.svelte
+++ b/components/restreamer/client/src/components/Restream.svelte
@@ -94,7 +94,9 @@
 
   $: orderedOutputs = undefined;
 
-  $: outputs = orderedOutputs ?? value.outputs.map(x => ({...x, restreamId: value.id}));
+  $: outputs =
+    orderedOutputs ??
+    value.outputs.map((x) => ({ ...x, restreamId: value.id }));
 
   $: deleteConfirmation = $info.data
     ? $info.data.info.deleteConfirmation
@@ -208,20 +210,18 @@
   }
 
   async function onDropOutput(e) {
-    console.log('onDropOutput: ', e)
-
     const ids = e.detail.items.map((x) => x.id);
     outputsHandleSort(e);
 
     orderWasUpdated = false;
 
-    const movedItem = e.detail.items.find(x => x.restreamId !== value.id);
+    const movedItem = e.detail.items.find((x) => x.restreamId !== value.id);
     if (movedItem) {
       await moveOutput(movedItem.id, value.id, movedItem.newIndex);
     } else {
       await updateOutputsOrder(ids);
     }
- }
+  }
 
   function onOutputDragStarted(e) {
     dragDisabled = e.details;
@@ -232,7 +232,7 @@
       const variables = {
         srcOutputId,
         dstRestreamId,
-        dstPosition
+        dstPosition,
       };
       await moveOutputMutation({ variables });
     } catch (e) {

--- a/components/restreamer/client/src/components/Restream.svelte
+++ b/components/restreamer/client/src/components/Restream.svelte
@@ -474,7 +474,7 @@
       display: none
 
     &:hover
-      .uk-close, .edit-input, .export-import, .uk-button-small, .full-view-link, .item-drag-zone
+      .uk-close, .edit-input, .export-import, .uk-button-small, .full-view-link, .item-drag-zone, .playlist-icon
         opacity: 1
 
     .uk-button-small
@@ -552,6 +552,9 @@
         height: 16px
 
     .playlist-icon
+      opacity: 0
+      transition: opacity .3s ease
+
       &.is-playing
         color: var(--success-color)
       :global(svg)

--- a/components/restreamer/client/src/components/Restream.svelte
+++ b/components/restreamer/client/src/components/Restream.svelte
@@ -33,7 +33,7 @@
   import { statusesList } from '../utils/constants';
 
   import { exportModal, outputModal } from '../stores';
-  import { UpdateOutputsOrder } from '../../api/client.graphql';
+  import { UpdateOutputsOrder, MoveOutput } from '../../api/client.graphql';
 
   import Confirm from './common/Confirm.svelte';
   import Input from './input/Input.svelte';
@@ -85,6 +85,7 @@
   };
 
   const updateOutputsOrderMutation = mutation(UpdateOutputsOrder);
+  const moveOutputMutation = mutation(MoveOutput);
 
   const playingFile = subscribe(CurrentlyPlayingFile, {
     variables: { id: value.id },
@@ -203,6 +204,7 @@
   }
 
   async function onDropOutput(e) {
+    console.log('onDropOutput: ', e)
     const ids = e.detail.items.map((x) => x.id);
     outputsHandleSort(e);
 
@@ -212,6 +214,15 @@
 
   function onOutputDragStarted(e) {
     dragDisabled = e.details;
+  }
+
+  async function moveOutputs(srcRestreamId, dstRestreamId, srcOutputId, dstPosition) {
+    try {
+      // const variables = { ids, restreamId: value.id };
+      await moveOutputMutation({ variables });
+    } catch (e) {
+      showError(e.message);
+    }
   }
 
   async function updateOutputsOrder(ids) {
@@ -429,7 +440,6 @@
           items: outputs,
           type: 'output',
           dropTargetClasses: ['drop-target'],
-          dropFromOthersDisabled: true,
           dragDisabled,
           flipDurationMs: 200,
         }}

--- a/components/restreamer/client/src/components/common/FileInfo.svelte
+++ b/components/restreamer/client/src/components/common/FileInfo.svelte
@@ -17,7 +17,7 @@
 
   export let file;
   export let showDownloadLink;
-  export let classList;
+  export let classList = '';
 
   $: fileDownloadProgress = getDownloadProgress(file);
 

--- a/components/restreamer/client/src/components/common/FileInfo.svelte
+++ b/components/restreamer/client/src/components/common/FileInfo.svelte
@@ -99,7 +99,7 @@
       {#if showDownloadLink}
         {#if isDownloading}
           <button
-            class="download-btn url-action-btn uk-button uk-button-link uk-margin-small-left"
+            class="download-btn url-action-btn uk-button uk-button-link"
             on:click|preventDefault={confirm(() => stopDownloadFile())}
           >
             Cancel
@@ -107,7 +107,7 @@
           </button>
         {:else}
           <button
-            class="download-btn url-action-btn uk-button uk-button-link uk-margin-small-left"
+            class="download-btn url-action-btn uk-button uk-button-link"
             on:click|preventDefault={confirm(() => downloadFile())}
           >
             Download

--- a/components/restreamer/client/src/components/common/ServerInfo.svelte
+++ b/components/restreamer/client/src/components/common/ServerInfo.svelte
@@ -1,7 +1,7 @@
 <script lang="js">
   import Fa from 'svelte-fa';
   import { isNumber } from '../../utils/util';
-  import { faInfoCircle } from '@fortawesome/free-solid-svg-icons/faInfoCircle';
+  import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
   export let serverInfo;
   export let rowMode = false;

--- a/components/restreamer/client/src/components/common/Shell.svelte
+++ b/components/restreamer/client/src/components/common/Shell.svelte
@@ -225,6 +225,9 @@
     color: var(--warning-color)
 
   .url-action-btn
+    white-space: nowrap
+    padding-right: 1em
+    padding-left: 1em
     align-self: center
     height: 100%
     color: var(--primary-text-color)

--- a/components/restreamer/client/src/components/common/StatusFilter.svelte
+++ b/components/restreamer/client/src/components/common/StatusFilter.svelte
@@ -1,14 +1,14 @@
 <script lang="js">
   import Fa from 'svelte-fa';
-  import { faInfoCircle } from '@fortawesome/free-solid-svg-icons/faInfoCircle';
+  import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
   import { STREAM_ERROR, STREAM_WARNING } from '../../utils/constants';
   import ToggleButton from './ToggleButton.svelte';
 
   export let count;
   export let active;
   export let status;
-  export let disabled;
-  export let title;
+  export let disabled = false;
+  export let title = '';
   export let handleClick = () => {};
 
   $: iconClass = getClass(status);

--- a/components/restreamer/client/src/components/common/StreamInfoDiffTooltip.svelte
+++ b/components/restreamer/client/src/components/common/StreamInfoDiffTooltip.svelte
@@ -1,6 +1,6 @@
 <script lang="js">
-  import { faInfoCircle } from '@fortawesome/free-solid-svg-icons/faInfoCircle';
   import Fa from 'svelte-fa';
+  import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
   export let streamsErrorsTooltip;
   export let streamsDiffTooltip;
@@ -15,7 +15,7 @@
       class:hidden={!streamsErrorsTooltip && !streamsDiffTooltip}
       uk-tooltip={streamsErrorsTooltip || streamsDiffTooltip}
     >
-      <Fa faInfoCircle icon={faInfoCircle} />
+      <Fa icon={faInfoCircle} />
     </span>
   {/key}
 </template>

--- a/components/restreamer/client/src/components/common/Url.svelte
+++ b/components/restreamer/client/src/components/common/Url.svelte
@@ -28,7 +28,7 @@
     {/if}
     {#if url}
       <button
-        class="url-action-btn uk-button uk-button-link uk-margin-small-left"
+        class="url-action-btn uk-button uk-button-link"
         on:click|preventDefault={() => copyToClipboard(url)}
       >
         Copy

--- a/components/restreamer/client/src/components/common/Url.svelte
+++ b/components/restreamer/client/src/components/common/Url.svelte
@@ -6,7 +6,7 @@
   import StreamInfo from './StreamInfo.svelte';
 
   export let url;
-  export let previewUrl;
+  export let previewUrl = false;
   export let streamInfo;
   export let isError;
 </script>

--- a/components/restreamer/client/src/components/input/Input.svelte
+++ b/components/restreamer/client/src/components/input/Input.svelte
@@ -20,9 +20,9 @@
   export let value;
   export let with_label;
   export let show_controls;
-  export let show_move_up;
-  export let show_move_down;
-  export let show_up_confirmation;
+  export let show_move_up = false;
+  export let show_move_down = false;
+  export let show_up_confirmation = true;
 
   $: isPull = !!value.src && value.src.__typename === 'RemoteInputSrc';
 

--- a/components/restreamer/src/api/graphql/client.rs
+++ b/components/restreamer/src/api/graphql/client.rs
@@ -392,6 +392,54 @@ impl MutationsRoot {
         Ok(true)
     }
 
+    ///
+    fn move_output(
+        #[graphql(description = "ID of the `Output` to be moved")]
+        src_output_id: OutputId,
+        #[graphql(description = "ID of the destination parent `Restream`")]
+        dst_restream_id: RestreamId,
+        #[graphql(description = "Position in destination array of `Output`s")]
+        dst_position: UNumber,
+        context: &Context,
+    ) -> Result<bool, graphql::Error> {
+        let mut restreams = context.state().restreams.lock_mut();
+
+        let (src_restream_id, output) = restreams
+            .iter_mut()
+            .find_map(|r| {
+                (r.outputs.iter().position(|o| o.id == src_output_id)).and_then(|pos| {
+                    let output = r.outputs.remove(pos);
+                    Some((r.id, output))
+                })
+            })
+            .ok_or(
+                graphql::Error::new("RESTREAM_NOT_FOUND")
+                    .status(StatusCode::BAD_REQUEST)
+                    .message(&format!("Source Restream or Output not found")),
+            )?;
+
+        let _ = context.state().disable_output(src_output_id, src_restream_id);
+
+        let dst_outputs = &mut restreams
+            .iter_mut()
+            .find(|r| r.id == dst_restream_id)
+            .ok_or(
+                graphql::Error::new("RESTREAM_NOT_FOUND")
+                    .status(StatusCode::BAD_REQUEST)
+                    .message(&format!("Restream {dst_restream_id} not found")),
+            )?
+            .outputs;
+
+        if dst_position > dst_outputs.len().into() {
+            return Err(graphql::Error::new("WRONG_ARRAY_INDEX")
+                .status(StatusCode::BAD_REQUEST)
+                .message(&format!("Can't insert output to destination position {}", dst_position.0)));
+        }
+
+        dst_outputs.insert(dst_position.into(), output);
+        Ok(true)
+    }
+
     /// Set playlist to [`Restream`]
     ///
     /// ### Result

--- a/components/restreamer/src/api/graphql/client.rs
+++ b/components/restreamer/src/api/graphql/client.rs
@@ -404,12 +404,13 @@ impl MutationsRoot {
     ) -> Result<bool, graphql::Error> {
         let mut restreams = context.state().restreams.lock_mut();
 
-        let (src_restream_id, output) = restreams
+        let output = restreams
             .iter_mut()
             .find_map(|r| {
                 (r.outputs.iter().position(|o| o.id == src_output_id)).and_then(|pos| {
-                    let output = r.outputs.remove(pos);
-                    Some((r.id, output))
+                    let mut output = r.outputs.remove(pos);
+                    output.enabled = false;
+                    Some(output)
                 })
             })
             .ok_or(
@@ -417,8 +418,6 @@ impl MutationsRoot {
                     .status(StatusCode::BAD_REQUEST)
                     .message(&format!("Source Restream or Output not found")),
             )?;
-
-        let _ = context.state().disable_output(src_output_id, src_restream_id);
 
         let dst_outputs = &mut restreams
             .iter_mut()

--- a/components/restreamer/src/types.rs
+++ b/components/restreamer/src/types.rs
@@ -35,7 +35,15 @@ impl From<UNumber> for usize {
 
 /// Generic number for using with Graphql
 #[derive(
-    Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, GraphQLScalar, PartialOrd
+    Debug,
+    Clone,
+    Copy,
+    Deserialize,
+    Serialize,
+    PartialEq,
+    Eq,
+    GraphQLScalar,
+    PartialOrd,
 )]
 pub struct UNumber(pub u16);
 
@@ -47,10 +55,9 @@ impl From<u16> for UNumber {
 
 impl From<usize> for UNumber {
     fn from(value: usize) -> Self {
-        if value <= u16::MAX as usize {
-            UNumber(value as u16)
-        } else {
-            UNumber(0)
+        match u16::try_from(value) {
+            Ok(value) => UNumber(value),
+            _ => UNumber(0),
         }
     }
 }

--- a/components/restreamer/src/types.rs
+++ b/components/restreamer/src/types.rs
@@ -27,11 +27,33 @@ impl Drop for DroppableAbortHandle {
     }
 }
 
+impl From<UNumber> for usize {
+    fn from(value: UNumber) -> Self {
+        value.0 as usize
+    }
+}
+
 /// Generic number for using with Graphql
 #[derive(
-    Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, GraphQLScalar,
+    Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, GraphQLScalar, PartialOrd
 )]
 pub struct UNumber(pub u16);
+
+impl From<u16> for UNumber {
+    fn from(value: u16) -> Self {
+        UNumber(value)
+    }
+}
+
+impl From<usize> for UNumber {
+    fn from(value: usize) -> Self {
+        if value <= u16::MAX as usize {
+            UNumber(value as u16)
+        } else {
+            UNumber(0)
+        }
+    }
+}
 
 impl TryFrom<i32> for UNumber {
     type Error = std::num::TryFromIntError;


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- New Feature: Introduced a new function `moveOutput` to the GraphQL schema and a corresponding mutation `MoveOutput` to enable moving outputs between restreams.
- Refactor: Removed the `files` export variable and its usage in the `All` component, potentially affecting its functionality.
- Refactor: Updated logic and rendering conditions in the `AppRestreamer` component, removing the usage of `Files` and error handling related to it.
- Style: Added a CSS class for text overflow handling in the `Output` component.
- Style: Removed a CSS class from buttons in the `Playlist` and `FileInfo` components.
- New Feature: Implemented drag and drop functionality between outputs in the `Restream` component.
- Style: Made CSS changes to various components for visual presentation.
- Refactor: Modified default values of exported variables in several components.
- New Feature: Added a new function `move_output` to the GraphQL client implementation in Rust.

> "Code changes dance,
> Features take a chance.
> Bugs step aside,
> As style takes its stride.
> With refactor's grace,
> The code finds its place."
<!-- end of auto-generated comment: release notes by openai -->